### PR TITLE
fix: add node-loader to vue config to fix build on mac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-standard": "^5.0.0",
         "eslint-plugin-vue": "^7.8.0",
+        "node-loader": "^1.0.3",
         "vue-cli-plugin-electron-builder": "2.0.0",
         "vue-cli-plugin-vuetify": "~2.4.0",
         "vue-template-compiler": "^2.6.11",
@@ -12032,6 +12033,58 @@
         "url": "^0.11.0",
         "util": "^0.11.0",
         "vm-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/node-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-1.0.3.tgz",
+      "integrity": "sha512-8c9ef5q24F0AjrPxUjdX7qdTlsU1zZCPeqYvSBCH1TJko3QW4qu1uA1C9KbOPdaRQwREDdbSYZgltBAlbV7l5g==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/node-loader/node_modules/loader-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+      "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/node-loader/node_modules/schema-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+      "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/node-releases": {
@@ -30056,6 +30109,40 @@
         "url": "^0.11.0",
         "util": "^0.11.0",
         "vm-browserify": "^1.0.1"
+      }
+    },
+    "node-loader": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/node-loader/-/node-loader-1.0.3.tgz",
+      "integrity": "sha512-8c9ef5q24F0AjrPxUjdX7qdTlsU1zZCPeqYvSBCH1TJko3QW4qu1uA1C9KbOPdaRQwREDdbSYZgltBAlbV7l5g==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
       }
     },
     "node-releases": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-vue": "^7.8.0",
+    "node-loader": "^1.0.3",
     "vue-cli-plugin-electron-builder": "2.0.0",
     "vue-cli-plugin-vuetify": "~2.4.0",
     "vue-template-compiler": "^2.6.11",

--- a/vue.config.js
+++ b/vue.config.js
@@ -12,6 +12,10 @@ module.exports = {
         {
           test: /\.worker\.(c|m)?js$/,
           loader: 'worker-loader'
+        },
+        {
+          test: /.node$/,
+          loader: 'node-loader'
         }
       ]
     }


### PR DESCRIPTION
Building the app on macOS was failing due to Webpack being unable to load native node moduels with the `.node` extension.

Solution:
Add `node-loader` to `package.json` and `vue.config.js`.

Fixes #25 