### PR TITLE
Fix winget command in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ You can install the app in one of these ways:
     <tr>
       <td>Windows (via winget)</td>
       <td width="320px">
-        <code>winget install sigma --source winget</code>
+        <code>winget install --id=AlekseyHoffman.Sigma-File-Manager --source winget</code>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
With current command, winget finds finds also the Store version and prints a Message, that multiple packages are found instead of installing.