### PR TITLE
"250GB free of 400GB" should be translated by "250GB libres sur 400GB" in French

### DIFF
--- a/src/localization/locales/fr.json
+++ b/src/localization/locales/fr.json
@@ -1413,7 +1413,7 @@
   "closedCaptions": "sous-titres",
   "protectedItemsShort": "Protégé",
   "pinnedItemsShort": "Attaché",
-  "freeOf": "gratuit de",
+  "freeOf": "libres sur",
   "terminal": "Terminal",
   "conflict": "Conflit"
 }


### PR DESCRIPTION
Previous translation ("gratuit de") means that it doesn't cost anything

"disponibles sur" is another way of translating it, but it's longer