### PR TITLE
UX (extensions): support contributed color themes

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -38,6 +38,30 @@ Call `await sigma.i18n.mergeFromPath('locales')` in `activate` before registerin
 
 `sigma.i18n.formatMessage` is available when you need `{placeholder}` formatting outside the translator.
 
+## Theme contributions
+
+Extensions can contribute color themes declaratively from `package.json`:
+
+```json
+{
+  "contributes": {
+    "themes": [
+      {
+        "id": "midnight",
+        "title": "Midnight",
+        "baseTheme": "dark",
+        "variables": {
+          "--background": "230 20% 10%",
+          "--primary": "200 80% 60%"
+        }
+      }
+    ]
+  }
+}
+```
+
+Theme contributions extend the host app's built-in light/dark token sets, so you usually only need to override the variables you want to change.
+
 ## Manifest schema
 
 In extension `package.json`:

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -38,30 +38,6 @@ Call `await sigma.i18n.mergeFromPath('locales')` in `activate` before registerin
 
 `sigma.i18n.formatMessage` is available when you need `{placeholder}` formatting outside the translator.
 
-## Theme contributions
-
-Extensions can contribute color themes declaratively from `package.json`:
-
-```json
-{
-  "contributes": {
-    "themes": [
-      {
-        "id": "midnight",
-        "title": "Midnight",
-        "baseTheme": "dark",
-        "variables": {
-          "--background": "230 20% 10%",
-          "--primary": "200 80% 60%"
-        }
-      }
-    ]
-  }
-}
-```
-
-Theme contributions extend the host app's built-in light/dark token sets, so you usually only need to override the variables you want to change.
-
 ## Manifest schema
 
 In extension `package.json`:

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -24,7 +24,7 @@ export async function activate(context: ExtensionActivationContext): Promise<voi
 export async function deactivate(): Promise<void> {}
 ```
 
-Point `package.json` `"main"` at your compiled file (for example `dist/index.js`), set `"type": "module"`, and build with `tsc` or your bundler. Commit build output if installs come from a Git tag archive without running a build on the client.
+When the extension runs code, point `package.json` `"main"` at your compiled file (for example `dist/index.js`), set `"type": "module"`, and build with `tsc` or your bundler. Manifest-only API extensions that only contribute themes can omit `"main"`. Commit build output if installs come from a Git tag archive without running a build on the client.
 
 ## i18n
 

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -104,6 +104,16 @@ export interface ExtensionConfiguration {
   properties: Record<string, ExtensionConfigurationProperty>;
 }
 
+export type ExtensionThemeBase = 'light' | 'dark';
+
+export interface ExtensionThemeContribution {
+  id: string;
+  title: string;
+  description?: string;
+  baseTheme: ExtensionThemeBase;
+  variables: Record<`--${string}`, string>;
+}
+
 export type ExtensionKeybindingWhen
   = | 'always'
     | 'fileSelected'
@@ -123,6 +133,7 @@ export interface ExtensionContributions {
   contextMenu?: ExtensionContextMenuItem[];
   sidebar?: ExtensionSidebarItem[];
   toolbar?: ExtensionToolbarDropdown[];
+  themes?: ExtensionThemeContribution[];
   configuration?: ExtensionConfiguration;
   keybindings?: ExtensionKeybinding[];
 }

--- a/packages/api/index.d.ts
+++ b/packages/api/index.d.ts
@@ -186,7 +186,7 @@ export interface ExtensionManifest {
   categories?: string[];
   tags?: string[];
   extensionType: ExtensionType;
-  main: string;
+  main?: string;
   permissions: ExtensionPermission[];
   activationEvents?: ExtensionActivationEvent[];
   contributes?: ExtensionContributions;

--- a/packages/api/manifest.schema.json
+++ b/packages/api/manifest.schema.json
@@ -354,6 +354,49 @@
             }
           }
         },
+        "themes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "title",
+              "baseTheme",
+              "variables"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z0-9-]+$"
+              },
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "baseTheme": {
+                "type": "string",
+                "enum": [
+                  "light",
+                  "dark"
+                ]
+              },
+              "variables": {
+                "type": "object",
+                "minProperties": 1,
+                "propertyNames": {
+                  "type": "string",
+                  "pattern": "^--[a-zA-Z0-9-]+$"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
         "configuration": {
           "type": "object",
           "properties": {

--- a/packages/api/manifest.schema.json
+++ b/packages/api/manifest.schema.json
@@ -11,9 +11,72 @@
     "repository",
     "license",
     "extensionType",
-    "main",
     "permissions",
     "engines"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "extensionType": {
+            "enum": [
+              "iframe",
+              "webview"
+            ]
+          }
+        },
+        "required": [
+          "extensionType"
+        ]
+      },
+      "then": {
+        "required": [
+          "main"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "extensionType": {
+            "enum": [
+              "api"
+            ]
+          }
+        },
+        "required": [
+          "extensionType"
+        ]
+      },
+      "then": {
+        "anyOf": [
+          {
+            "required": [
+              "main"
+            ]
+          },
+          {
+            "required": [
+              "contributes"
+            ],
+            "properties": {
+              "contributes": {
+                "required": [
+                  "themes"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "themes": {
+                    "type": "array",
+                    "minItems": 1
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
   ],
   "properties": {
     "id": {
@@ -144,7 +207,7 @@
     },
     "main": {
       "type": "string",
-      "description": "Entry point file"
+      "description": "Entry point file. Required for iframe/webview extensions and API extensions that run code."
     },
     "permissions": {
       "type": "array",

--- a/src/modules/extensions/runtime/__tests__/loader.test.ts
+++ b/src/modules/extensions/runtime/__tests__/loader.test.ts
@@ -180,6 +180,39 @@ describe('extension runtime loader', () => {
     });
   });
 
+  it('loads theme-only api extensions without an entry module', async () => {
+    const { main: omittedMain, ...manifest } = {
+      ...createManifest(),
+      permissions: [],
+      contributes: {
+        themes: [
+          {
+            id: 'midnight',
+            title: 'Midnight',
+            baseTheme: 'dark' as const,
+            variables: {
+              '--background': '230 20% 10%',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(omittedMain).toBe('index.js');
+
+    await loadExtensionRuntime('test.video', manifest, 'onStartup');
+
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(createExtensionAPIMock).not.toHaveBeenCalled();
+    expect(initializeWorkerMock).not.toHaveBeenCalled();
+    expect(activateWorkerMock).not.toHaveBeenCalled();
+    expect(getLoadedRuntime('test.video')).toMatchObject({
+      id: 'test.video',
+      instance: null,
+      workerHost: null,
+    });
+  });
+
   it('loads Windows api extensions through blob module URLs', async () => {
     invokeMock.mockImplementation(async (command: string, args?: { filePath?: string }) => {
       switch (command) {

--- a/src/modules/extensions/runtime/__tests__/validation.test.ts
+++ b/src/modules/extensions/runtime/__tests__/validation.test.ts
@@ -169,6 +169,65 @@ describe('manifest theme validation', () => {
     expect(() => assertValidManifestData(manifest)).not.toThrow();
   });
 
+  it('accepts theme-only api extensions without a main entry', () => {
+    const { main: omittedMain, ...manifest } = {
+      ...createManifest(),
+      permissions: [],
+      contributes: {
+        themes: [
+          {
+            id: 'midnight',
+            title: 'Midnight',
+            baseTheme: 'dark',
+            variables: {
+              '--background': '230 20% 10%',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(omittedMain).toBe('index.js');
+    expect(() => assertValidManifestData(manifest)).not.toThrow();
+  });
+
+  it('rejects api extensions without a main entry unless they only contribute themes', () => {
+    const { main: omittedMain, ...manifest } = {
+      ...createManifest(),
+      contributes: {
+        themes: [
+          {
+            id: 'midnight',
+            title: 'Midnight',
+            baseTheme: 'dark',
+            variables: {
+              '--background': '230 20% 10%',
+            },
+          },
+        ],
+        commands: [
+          {
+            id: 'open',
+            title: 'Open',
+          },
+        ],
+      },
+    };
+
+    expect(omittedMain).toBe('index.js');
+    expect(() => assertValidManifestData(manifest)).toThrow('Invalid manifest: main is missing');
+  });
+
+  it('rejects iframe extensions without a main entry', () => {
+    const { main: omittedMain, ...manifest } = {
+      ...createManifest(),
+      extensionType: 'iframe',
+    };
+
+    expect(omittedMain).toBe('index.js');
+    expect(() => assertValidManifestData(manifest)).toThrow('Invalid manifest: main is missing');
+  });
+
   it('rejects theme contributions without css variables', () => {
     const manifest = {
       ...createManifest(),

--- a/src/modules/extensions/runtime/__tests__/validation.test.ts
+++ b/src/modules/extensions/runtime/__tests__/validation.test.ts
@@ -146,3 +146,72 @@ describe('manifest binary validation', () => {
     expect(() => assertValidManifestData(manifest)).toThrow('Invalid manifest: binaries are invalid');
   });
 });
+
+describe('manifest theme validation', () => {
+  it('accepts valid theme contributions', () => {
+    const manifest = {
+      ...createManifest(),
+      contributes: {
+        themes: [
+          {
+            id: 'midnight',
+            title: 'Midnight',
+            baseTheme: 'dark',
+            variables: {
+              '--background': '230 20% 10%',
+              '--primary': '200 80% 60%',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => assertValidManifestData(manifest)).not.toThrow();
+  });
+
+  it('rejects theme contributions without css variables', () => {
+    const manifest = {
+      ...createManifest(),
+      contributes: {
+        themes: [
+          {
+            id: 'broken-theme',
+            title: 'Broken Theme',
+            baseTheme: 'dark',
+            variables: {},
+          },
+        ],
+      },
+    };
+
+    expect(() => assertValidManifestData(manifest)).toThrow('Invalid manifest: contributes are invalid');
+  });
+
+  it('rejects duplicate theme ids within one extension', () => {
+    const manifest = {
+      ...createManifest(),
+      contributes: {
+        themes: [
+          {
+            id: 'midnight',
+            title: 'Midnight',
+            baseTheme: 'dark',
+            variables: {
+              '--background': '230 20% 10%',
+            },
+          },
+          {
+            id: 'midnight',
+            title: 'Midnight 2',
+            baseTheme: 'dark',
+            variables: {
+              '--background': '230 20% 12%',
+            },
+          },
+        ],
+      },
+    };
+
+    expect(() => assertValidManifestData(manifest)).toThrow('Invalid manifest: contributes are invalid');
+  });
+});

--- a/src/modules/extensions/runtime/loader.ts
+++ b/src/modules/extensions/runtime/loader.ts
@@ -147,6 +147,16 @@ function getExtensionAssetUrl(extensionPath: string, mainFile: string): string {
   return convertFileSrc(`${normalizedExtensionPath}/${normalizedMainFile}`);
 }
 
+function registerManifestContributions(extensionId: string, manifest: ExtensionManifest): void {
+  if (manifest.contributes?.configuration) {
+    registerExtensionConfiguration(extensionId, manifest.contributes.configuration);
+  }
+
+  if (manifest.contributes?.keybindings) {
+    registerExtensionKeybindings(extensionId, manifest.contributes.keybindings);
+  }
+}
+
 function normalizeExtensionRelativePath(path: string): string {
   return normalizePath(path).replace(/^\/+/, '');
 }
@@ -312,9 +322,15 @@ async function loadApiExtension(
 ): Promise<void> {
   const { id: extensionId, manifest } = runtime;
 
+  registerManifestContributions(extensionId, manifest);
+
+  if (!manifest.main) {
+    return;
+  }
+
   const extensionPath = await invokeAsExtension<string>(extensionId, 'get_extension_path', { extensionId });
   const storagePath = await invokeAsExtension<string>(extensionId, 'get_extension_storage_path', { extensionId });
-  const mainFile = manifest.main || 'index.js';
+  const mainFile = manifest.main;
 
   const fileExists = await invokeAsExtension<boolean>(extensionId, 'extension_path_exists', {
     extensionId,
@@ -323,14 +339,6 @@ async function loadApiExtension(
 
   if (!fileExists) {
     throw new Error(`Extension ${extensionId} main file not found: ${mainFile}`);
-  }
-
-  if (manifest.contributes?.configuration) {
-    registerExtensionConfiguration(extensionId, manifest.contributes.configuration);
-  }
-
-  if (manifest.contributes?.keybindings) {
-    registerExtensionKeybindings(extensionId, manifest.contributes.keybindings);
   }
 
   const api = createExtensionAPI(extensionId, manifest.permissions);
@@ -421,13 +429,7 @@ async function loadIframeExtension(
   iframe.src = iframeSource;
   runtime.iframeOrigin = new URL(iframeSource).origin;
 
-  if (manifest.contributes?.configuration) {
-    registerExtensionConfiguration(extensionId, manifest.contributes.configuration);
-  }
-
-  if (manifest.contributes?.keybindings) {
-    registerExtensionKeybindings(extensionId, manifest.contributes.keybindings);
-  }
+  registerManifestContributions(extensionId, manifest);
 
   const api = createExtensionAPI(extensionId, manifest.permissions);
   runtime.api = api;

--- a/src/modules/extensions/runtime/validation.ts
+++ b/src/modules/extensions/runtime/validation.ts
@@ -150,6 +150,21 @@ function isValidManifestContributions(value: unknown): boolean {
   return true;
 }
 
+function hasThemeContributions(value: unknown): boolean {
+  return isObjectRecord(value)
+    && Array.isArray(value.themes)
+    && value.themes.length > 0;
+}
+
+function canOmitManifestMain(value: Record<string, unknown>): boolean {
+  if (value.extensionType !== 'api' || !hasThemeContributions(value.contributes)) {
+    return false;
+  }
+
+  return isObjectRecord(value.contributes)
+    && Object.keys(value.contributes).every(contributionKey => contributionKey === 'themes');
+}
+
 function isValidManifestBinaryAsset(value: unknown): boolean {
   if (!isObjectRecord(value)) {
     return false;
@@ -441,7 +456,15 @@ export function assertValidManifestData(data: unknown): asserts data is Extensio
     throw new Error('Invalid manifest: extension type is invalid');
   }
 
-  if (!isNonEmptyString(data.main)) {
+  if (data.contributes !== undefined && !isValidManifestContributions(data.contributes)) {
+    throw new Error('Invalid manifest: contributes are invalid');
+  }
+
+  if (data.main !== undefined && !isNonEmptyString(data.main)) {
+    throw new Error('Invalid manifest: main is missing');
+  }
+
+  if (data.main === undefined && !canOmitManifestMain(data)) {
     throw new Error('Invalid manifest: main is missing');
   }
 
@@ -457,10 +480,6 @@ export function assertValidManifestData(data: unknown): asserts data is Extensio
     if (!Array.isArray(data.binaries) || data.binaries.some(binary => !isValidManifestBinaryDefinition(binary))) {
       throw new Error('Invalid manifest: binaries are invalid');
     }
-  }
-
-  if (data.contributes !== undefined && !isValidManifestContributions(data.contributes)) {
-    throw new Error('Invalid manifest: contributes are invalid');
   }
 
   if (!isObjectRecord(data.engines) || !isNonEmptyString(data.engines.sigmaFileManager)) {

--- a/src/modules/extensions/runtime/validation.ts
+++ b/src/modules/extensions/runtime/validation.ts
@@ -28,6 +28,7 @@ const VALID_PERMISSIONS: string[] = [
 
 const VALID_PLATFORMS = ['windows', 'macos', 'linux'] as const;
 const VALID_ARCHES = ['x64', 'arm64'] as const;
+const EXTENSION_THEME_ID_PATTERN = /^[a-z0-9-]+$/;
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -78,6 +79,75 @@ function isSafeRelativePath(value: string): boolean {
 
 function isValidIntegrity(value: unknown): value is string {
   return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/i.test(value.trim());
+}
+
+function isValidThemeVariables(value: unknown): value is Record<`--${string}`, string> {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  const entries = Object.entries(value);
+
+  if (entries.length === 0) {
+    return false;
+  }
+
+  return entries.every(([key, cssValue]) => {
+    return /^--[a-zA-Z0-9-]+$/.test(key)
+      && isNonEmptyString(cssValue);
+  });
+}
+
+function isValidThemeContribution(value: unknown): boolean {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  if (!isNonEmptyString(value.id) || !EXTENSION_THEME_ID_PATTERN.test(value.id)) {
+    return false;
+  }
+
+  if (!isNonEmptyString(value.title)) {
+    return false;
+  }
+
+  if (value.description !== undefined && !isNonEmptyString(value.description)) {
+    return false;
+  }
+
+  if (value.baseTheme !== 'light' && value.baseTheme !== 'dark') {
+    return false;
+  }
+
+  if (!isValidThemeVariables(value.variables)) {
+    return false;
+  }
+
+  return true;
+}
+
+function isValidManifestContributions(value: unknown): boolean {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  if (value.themes !== undefined) {
+    if (!Array.isArray(value.themes) || value.themes.some(theme => !isValidThemeContribution(theme))) {
+      return false;
+    }
+
+    const seenThemeIds = new Set<string>();
+
+    for (const theme of value.themes) {
+      if (!isObjectRecord(theme) || !isNonEmptyString(theme.id) || seenThemeIds.has(theme.id)) {
+        return false;
+      }
+
+      seenThemeIds.add(theme.id);
+    }
+  }
+
+  return true;
 }
 
 function isValidManifestBinaryAsset(value: unknown): boolean {
@@ -387,6 +457,10 @@ export function assertValidManifestData(data: unknown): asserts data is Extensio
     if (!Array.isArray(data.binaries) || data.binaries.some(binary => !isValidManifestBinaryDefinition(binary))) {
       throw new Error('Invalid manifest: binaries are invalid');
     }
+  }
+
+  if (data.contributes !== undefined && !isValidManifestContributions(data.contributes)) {
+    throw new Error('Invalid manifest: contributes are invalid');
   }
 
   if (!isObjectRecord(data.engines) || !isNonEmptyString(data.engines.sigmaFileManager)) {

--- a/src/modules/settings/ui/categories/appearance/theme.vue
+++ b/src/modules/settings/ui/categories/appearance/theme.vue
@@ -13,35 +13,52 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { SettingsItem } from '@/modules/settings';
+import {
+  getAvailableThemeOptions,
+  normalizeThemeSelection,
+} from '@/modules/themes/registry';
+import { useExtensionsStorageStore } from '@/stores/storage/extensions';
 import { useUserSettingsStore } from '@/stores/storage/user-settings';
-import type { Theme } from '@/types/user-settings';
 import { useI18n } from 'vue-i18n';
 import { computed } from 'vue';
 import { SunMoonIcon } from '@lucide/vue';
 
+const extensionsStorageStore = useExtensionsStorageStore();
 const userSettingsStore = useUserSettingsStore();
 const { t } = useI18n();
 
-const themeOptions: {
-  name: string;
-  value: Theme;
-}[] = [
-  {
-    name: t('settings.homeBannerEffects.theme.themeTypeRadio.dark'),
-    value: 'dark',
-  },
-  {
-    name: t('settings.homeBannerEffects.theme.themeTypeRadio.light'),
-    value: 'light',
-  },
-  {
-    name: t('system'),
-    value: 'system',
-  },
-];
+const themeOptions = computed(() => {
+  return getAvailableThemeOptions(extensionsStorageStore.extensionsData.installedExtensions).map((option) => {
+    if (option.source === 'builtin') {
+      return {
+        name: option.builtinThemeId === 'dark'
+          ? t('settings.homeBannerEffects.theme.themeTypeRadio.dark')
+          : option.builtinThemeId === 'light'
+            ? t('settings.homeBannerEffects.theme.themeTypeRadio.light')
+            : t('system'),
+        value: option.id,
+      };
+    }
+
+    return {
+      name: option.title,
+      value: option.id,
+    };
+  });
+});
+
+const selectedThemeId = computed(() => {
+  return normalizeThemeSelection(
+    userSettingsStore.userSettings.theme,
+    extensionsStorageStore.extensionsData.installedExtensions,
+  );
+});
 
 const selectedTheme = computed({
-  get: () => themeOptions.find(option => option.value === userSettingsStore.userSettings.theme),
+  get: () => {
+    return themeOptions.value.find(option => option.value === selectedThemeId.value)
+      ?? themeOptions.value[0];
+  },
   set: (option) => {
     if (option) {
       userSettingsStore.set('theme', option.value);

--- a/src/modules/themes/__tests__/registry.test.ts
+++ b/src/modules/themes/__tests__/registry.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// License: GNU GPLv3 or later. See the license file in the project root for more information.
+// Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
+
+import { describe, expect, it } from 'vitest';
+import type { InstalledExtensionData } from '@/types/extension';
+import {
+  createExtensionThemeId,
+  getAvailableThemeOptions,
+  normalizeThemeSelection,
+  parseThemeId,
+} from '@/modules/themes/registry';
+
+function createInstalledExtensionData(
+  overrides: Partial<InstalledExtensionData> = {},
+): InstalledExtensionData {
+  return {
+    version: '1.0.0',
+    enabled: true,
+    autoUpdate: true,
+    installedAt: 1,
+    manifest: {
+      id: 'test.palette',
+      name: 'Test Palette',
+      version: '1.0.0',
+      repository: 'https://github.com/example/test-palette',
+      license: 'MIT',
+      extensionType: 'api',
+      main: 'index.js',
+      permissions: [],
+      contributes: {
+        themes: [
+          {
+            id: 'midnight',
+            title: 'Midnight',
+            baseTheme: 'dark',
+            variables: {
+              '--background': '230 20% 10%',
+            },
+          },
+        ],
+      },
+      engines: {
+        sigmaFileManager: '>=2.0.0',
+      },
+    },
+    settings: {
+      scopedDirectories: [],
+      customSettings: {},
+    },
+    ...overrides,
+  };
+}
+
+describe('theme registry', () => {
+  it('includes built-in themes and enabled extension themes', () => {
+    const availableThemes = getAvailableThemeOptions({
+      'test.palette': createInstalledExtensionData(),
+      'test.disabled': createInstalledExtensionData({
+        enabled: false,
+        manifest: {
+          ...createInstalledExtensionData().manifest,
+          id: 'test.disabled',
+          contributes: {
+            themes: [
+              {
+                id: 'sunrise',
+                title: 'Sunrise',
+                baseTheme: 'light',
+                variables: {
+                  '--background': '30 100% 98%',
+                },
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    expect(availableThemes.map(theme => theme.id)).toEqual([
+      'dark',
+      'light',
+      'system',
+      'extension:test.palette:midnight',
+    ]);
+  });
+
+  it('normalizes missing extension themes back to dark', () => {
+    expect(normalizeThemeSelection('extension:test.palette:missing', {})).toBe('dark');
+  });
+
+  it('parses extension theme ids', () => {
+    expect(parseThemeId(createExtensionThemeId('test.palette', 'midnight'))).toEqual({
+      source: 'extension',
+      extensionId: 'test.palette',
+      themeId: 'midnight',
+    });
+  });
+});

--- a/src/modules/themes/registry.ts
+++ b/src/modules/themes/registry.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// License: GNU GPLv3 or later. See the license file in the project root for more information.
+// Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
+
+import type { InstalledExtensionData } from '@/types/extension';
+import type { BuiltinThemeId, Theme } from '@/types/user-settings';
+
+export const BUILTIN_THEME_IDS = ['dark', 'light', 'system'] as const;
+export const DEFAULT_THEME_ID: BuiltinThemeId = 'dark';
+
+type ResolvedBuiltinThemeId = Exclude<BuiltinThemeId, 'system'>;
+
+type BuiltinThemeOption = {
+  id: BuiltinThemeId;
+  source: 'builtin';
+  builtinThemeId: BuiltinThemeId;
+};
+
+type ExtensionThemeOption = {
+  id: Theme;
+  source: 'extension';
+  extensionId: string;
+  themeId: string;
+  title: string;
+  description?: string;
+  baseTheme: ResolvedBuiltinThemeId;
+  variables: Record<`--${string}`, string>;
+};
+
+export type ThemeOption = BuiltinThemeOption | ExtensionThemeOption;
+
+type ParsedBuiltinThemeId = {
+  source: 'builtin';
+  builtinThemeId: BuiltinThemeId;
+};
+
+type ParsedExtensionThemeId = {
+  source: 'extension';
+  extensionId: string;
+  themeId: string;
+};
+
+type ParsedThemeId = ParsedBuiltinThemeId | ParsedExtensionThemeId;
+
+const EXTENSION_THEME_PREFIX = 'extension:';
+const EXTENSION_THEME_ID_PATTERN = /^[a-z0-9-]+$/;
+
+export function createExtensionThemeId(extensionId: string, themeId: string): Theme {
+  return `${EXTENSION_THEME_PREFIX}${extensionId}:${themeId}` as Theme;
+}
+
+export function parseThemeId(theme: string): ParsedThemeId | null {
+  if (theme === 'dark' || theme === 'light' || theme === 'system') {
+    return {
+      source: 'builtin',
+      builtinThemeId: theme,
+    };
+  }
+
+  if (!theme.startsWith(EXTENSION_THEME_PREFIX)) {
+    return null;
+  }
+
+  const identifier = theme.slice(EXTENSION_THEME_PREFIX.length);
+  const separatorIndex = identifier.indexOf(':');
+
+  if (separatorIndex <= 0 || separatorIndex === identifier.length - 1) {
+    return null;
+  }
+
+  const extensionId = identifier.slice(0, separatorIndex);
+  const themeId = identifier.slice(separatorIndex + 1);
+
+  if (!EXTENSION_THEME_ID_PATTERN.test(themeId)) {
+    return null;
+  }
+
+  return {
+    source: 'extension',
+    extensionId,
+    themeId,
+  };
+}
+
+export function getBuiltinThemeOptions(): ThemeOption[] {
+  return BUILTIN_THEME_IDS.map(themeId => ({
+    id: themeId,
+    source: 'builtin' as const,
+    builtinThemeId: themeId,
+  }));
+}
+
+export function getExtensionThemeOptions(
+  installedExtensions: Record<string, InstalledExtensionData>,
+): ThemeOption[] {
+  const themeOptions: ThemeOption[] = [];
+
+  for (const [extensionId, extension] of Object.entries(installedExtensions)) {
+    if (!extension.enabled || extension.installPendingDependencies) {
+      continue;
+    }
+
+    const contributedThemes = extension.manifest.contributes?.themes ?? [];
+
+    for (const theme of contributedThemes) {
+      themeOptions.push({
+        id: createExtensionThemeId(extensionId, theme.id),
+        source: 'extension',
+        extensionId,
+        themeId: theme.id,
+        title: theme.title,
+        description: theme.description,
+        baseTheme: theme.baseTheme,
+        variables: theme.variables,
+      });
+    }
+  }
+
+  return themeOptions.sort((left, right) => {
+    const extensionCompare = left.source === 'extension' && right.source === 'extension'
+      ? left.extensionId.localeCompare(right.extensionId)
+      : 0;
+
+    if (extensionCompare !== 0) {
+      return extensionCompare;
+    }
+
+    if (left.source === 'extension' && right.source === 'extension') {
+      return left.title.localeCompare(right.title);
+    }
+
+    return 0;
+  });
+}
+
+export function getAvailableThemeOptions(
+  installedExtensions: Record<string, InstalledExtensionData>,
+): ThemeOption[] {
+  return [
+    ...getBuiltinThemeOptions(),
+    ...getExtensionThemeOptions(installedExtensions),
+  ];
+}
+
+export function findThemeOption(
+  theme: string,
+  installedExtensions: Record<string, InstalledExtensionData>,
+): ThemeOption | undefined {
+  const parsedTheme = parseThemeId(theme);
+
+  if (!parsedTheme) {
+    return undefined;
+  }
+
+  if (parsedTheme.source === 'builtin') {
+    return getBuiltinThemeOptions().find(option => option.id === parsedTheme.builtinThemeId);
+  }
+
+  return getExtensionThemeOptions(installedExtensions).find((option) => {
+    return option.source === 'extension'
+      && option.extensionId === parsedTheme.extensionId
+      && option.themeId === parsedTheme.themeId;
+  });
+}
+
+export function normalizeThemeSelection(
+  theme: string,
+  installedExtensions: Record<string, InstalledExtensionData>,
+): Theme {
+  const selectedTheme = findThemeOption(theme, installedExtensions);
+  return (selectedTheme?.id ?? DEFAULT_THEME_ID) as Theme;
+}

--- a/src/stores/storage/composables/__tests__/use-theme.test.ts
+++ b/src/stores/storage/composables/__tests__/use-theme.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// License: GNU GPLv3 or later. See the license file in the project root for more information.
+// Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
+
+import { nextTick, ref } from 'vue';
+import {
+  beforeEach, describe, expect, it, vi,
+} from 'vitest';
+import type { InstalledExtensionData } from '@/types/extension';
+import type { Theme } from '@/types/user-settings';
+
+const extensionsData = {
+  installedExtensions: {} as Record<string, InstalledExtensionData>,
+};
+
+vi.mock('@/stores/storage/extensions', () => ({
+  useExtensionsStorageStore: () => ({
+    extensionsData,
+  }),
+}));
+
+import { useTheme } from '@/stores/storage/composables/use-theme';
+
+function createInstalledExtensionData(): InstalledExtensionData {
+  return {
+    version: '1.0.0',
+    enabled: true,
+    autoUpdate: true,
+    installedAt: 1,
+    manifest: {
+      id: 'test.palette',
+      name: 'Test Palette',
+      version: '1.0.0',
+      repository: 'https://github.com/example/test-palette',
+      license: 'MIT',
+      extensionType: 'api',
+      main: 'index.js',
+      permissions: [],
+      contributes: {
+        themes: [
+          {
+            id: 'midnight',
+            title: 'Midnight',
+            baseTheme: 'dark',
+            variables: {
+              '--primary': '200 80% 60%',
+            },
+          },
+        ],
+      },
+      engines: {
+        sigmaFileManager: '>=2.0.0',
+      },
+    },
+    settings: {
+      scopedDirectories: [],
+      customSettings: {},
+    },
+  };
+}
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    document.documentElement.className = '';
+    document.documentElement.style.cssText = '';
+    extensionsData.installedExtensions = {};
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+      })),
+    });
+  });
+
+  it('applies extension theme variables and removes them when switching away', async () => {
+    extensionsData.installedExtensions = {
+      'test.palette': createInstalledExtensionData(),
+    };
+
+    const theme = ref<Theme>('extension:test.palette:midnight');
+    const { currentTheme } = useTheme(theme);
+
+    expect(currentTheme.value).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('--primary')).toBe('200 80% 60%');
+
+    theme.value = 'light';
+    await nextTick();
+
+    expect(currentTheme.value).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(document.documentElement.style.getPropertyValue('--primary')).toBe('');
+  });
+});

--- a/src/stores/storage/composables/use-theme.ts
+++ b/src/stores/storage/composables/use-theme.ts
@@ -6,18 +6,64 @@ import {
   ref, computed, type Ref, type ComputedRef, watchEffect,
 } from 'vue';
 import type { Theme } from '@/types/user-settings';
+import { findThemeOption, parseThemeId } from '@/modules/themes/registry';
+import { useExtensionsStorageStore } from '@/stores/storage/extensions';
 
 export function useTheme(themeSettingRef: Ref<Theme> | ComputedRef<Theme>) {
+  const extensionsStorageStore = useExtensionsStorageStore();
   const currentTheme = ref<'light' | 'dark'>('dark');
   const isDark = computed(() => currentTheme.value === 'dark');
+  const appliedThemeVariables = new Set<string>();
 
   function getSystemPreference(): 'light' | 'dark' {
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   }
 
-  function setTheme(theme: Theme) {
-    currentTheme.value = theme === 'system' ? getSystemPreference() : theme;
+  function clearThemeVariables() {
+    if (typeof document === 'undefined' || !document.documentElement) {
+      return;
+    }
+
+    for (const variableName of appliedThemeVariables) {
+      document.documentElement.style.removeProperty(variableName);
+    }
+
+    appliedThemeVariables.clear();
+  }
+
+  function applyBaseTheme(theme: 'light' | 'dark') {
+    currentTheme.value = theme;
     document.documentElement.classList.toggle('dark', currentTheme.value === 'dark');
+  }
+
+  function resolveBuiltinTheme(theme: 'light' | 'dark' | 'system'): 'light' | 'dark' {
+    return theme === 'system' ? getSystemPreference() : theme;
+  }
+
+  function setTheme(theme: Theme) {
+    clearThemeVariables();
+
+    const themeOption = findThemeOption(
+      theme,
+      extensionsStorageStore.extensionsData.installedExtensions,
+    );
+
+    if (!themeOption || themeOption.source === 'builtin') {
+      const parsedTheme = parseThemeId(theme);
+      const resolvedTheme = parsedTheme?.source === 'builtin'
+        ? resolveBuiltinTheme(parsedTheme.builtinThemeId)
+        : 'dark';
+
+      applyBaseTheme(resolvedTheme);
+      return;
+    }
+
+    applyBaseTheme(themeOption.baseTheme);
+
+    for (const [variableName, variableValue] of Object.entries(themeOption.variables)) {
+      document.documentElement.style.setProperty(variableName, variableValue);
+      appliedThemeVariables.add(variableName);
+    }
   }
 
   function toggleTheme() {
@@ -25,8 +71,10 @@ export function useTheme(themeSettingRef: Ref<Theme> | ComputedRef<Theme>) {
   }
 
   function handleSystemThemeChange(event: MediaQueryListEvent) {
-    if (themeSettingRef.value === 'system') {
-      setTheme(event.matches ? 'dark' : 'light');
+    const parsedTheme = parseThemeId(themeSettingRef.value);
+
+    if (parsedTheme?.source === 'builtin' && parsedTheme.builtinThemeId === 'system') {
+      applyBaseTheme(event.matches ? 'dark' : 'light');
     }
   }
 

--- a/src/stores/storage/user-settings.ts
+++ b/src/stores/storage/user-settings.ts
@@ -14,8 +14,10 @@ import {
   DEFAULT_BACKGROUND_FILE_NAME,
   DEFAULT_INFUSION_BACKGROUND_FILE_NAME,
 } from '@/data/background-media';
+import { normalizeThemeSelection } from '@/modules/themes/registry';
 import { useTheme } from './composables/use-theme';
 import { useUserPathsStore } from './user-paths';
+import { useExtensionsStorageStore } from './extensions';
 import { i18n } from '@/localization';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import {
@@ -34,6 +36,7 @@ import {
 
 export const useUserSettingsStore = defineStore('userSettings', () => {
   const userPathsStore = useUserPathsStore();
+  const extensionsStorageStore = useExtensionsStorageStore();
 
   const userSettingsStorage = ref<LazyStore | null>(null);
   const userSettingsDefault = ref<UserSettings | null>(null);
@@ -241,6 +244,16 @@ export const useUserSettingsStore = defineStore('userSettings', () => {
     () => userSettings.value.text?.font ?? 'system-ui',
   );
   const themeSettingRef = computed(() => userSettings.value.theme);
+  const normalizedThemeSelection = computed(() => {
+    if (!extensionsStorageStore.isInitialized) {
+      return userSettings.value.theme;
+    }
+
+    return normalizeThemeSelection(
+      userSettings.value.theme,
+      extensionsStorageStore.extensionsData.installedExtensions,
+    );
+  });
   const { setTheme } = useTheme(themeSettingRef);
 
   watch(
@@ -258,6 +271,14 @@ export const useUserSettingsStore = defineStore('userSettings', () => {
     },
     { immediate: true },
   );
+
+  watch(normalizedThemeSelection, (normalizedTheme) => {
+    if (!extensionsStorageStore.isInitialized || normalizedTheme === userSettings.value.theme) {
+      return;
+    }
+
+    void set('theme', normalizedTheme);
+  });
 
   function applyUserSettingsEntries(settingsEntries: Iterable<[string, unknown]>) {
     for (const [key, value] of settingsEntries) {

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -201,7 +201,8 @@ export type LocalizationLanguage = {
   isRtl: boolean;
 };
 
-export type Theme = 'light' | 'dark' | 'system';
+export type BuiltinThemeId = 'light' | 'dark' | 'system';
+export type Theme = BuiltinThemeId | `extension:${string}:${string}`;
 
 export type DateTime = {
   month: 'numeric' | 'short' | 'long';


### PR DESCRIPTION
## Summary
 
 Adds support for declarative extension-contributed color themes.
 
 Extensions can now contribute themes through the manifest, enabled extension themes appear in **Settings > Theme**, and theme selections are persisted 
safely with a built-in fallback if an extension theme becomes unavailable.
 
 ## What changed
 
 - Added `contributes.themes` to the extension API types
 - Extended the extension manifest schema for theme contributions
 - Added runtime validation for contributed themes
 - Introduced a theme registry that combines built-in themes with enabled extension themes
 - Updated theme persistence to support extension theme IDs with safe fallback behavior
 - Extended theme application to layer extension-provided CSS variables on top of a light/dark base theme
 - Updated **Settings > Theme** to render theme options dynamically
 - Added tests for:
   - manifest validation
   - theme registry behavior
   - theme application behavior
 
 ## Theme contribution model
 
 This PR uses a host-managed declarative model for extension themes:
 
 - extensions declare theme metadata and CSS variable overrides in the manifest
 - the host app controls registration, selection, application, cleanup, and fallback behavior
 - built-in `light`, `dark`, and `system` behavior remains intact
 
 ## Notes
 
 - This PR adds the platform support for extension-contributed themes only
 - It does **not** bundle or introduce any specific third-party theme pack as part of Sigma File Manager itself
 - As an example theme pack, reviewers can download [cos-overclock/sfm-catppuccin-themes](https://github.com/cos-overclock/sfm-catppuccin-themes) and  install it via **Extensions > Local install** to try the feature end-to-end
 
 ## Validation
 
 - `npm run type-check`
 - `npm run lint:check`
 - `npm run test:unit:run -- "src\modules\themes\__tests__\registry.test.ts" "src\stores\storage\composables\__tests__\use-theme.test.ts" 
"src\modules\extensions\runtime\__tests__\validation.test.ts"`