### PR TITLE
Improved Address Bar Focus Behavior and Shortcut Customization

### DIFF
--- a/src/modules/navigator/components/file-browser/address-bar.vue
+++ b/src/modules/navigator/components/file-browser/address-bar.vue
@@ -3,6 +3,16 @@ License: GNU GPLv3 or later. See the license file in the project root for more i
 Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
 -->
 
+<script lang="ts">
+type AddressBarController = {
+  isActivePane: () => boolean;
+  openEditor: () => Promise<void>;
+};
+
+const addressBarInstances: AddressBarController[] = [];
+let shortcutHandlerRegistered = false;
+</script>
+
 <script setup lang="ts">
 import {
   ref,
@@ -20,6 +30,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { onClickOutside, useDebounceFn } from '@vueuse/core';
+import { useFileBrowserContext } from './composables/use-file-browser-context';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -59,6 +70,7 @@ const emit = defineEmits<{
 
 const { t } = useI18n();
 const shortcutsStore = useShortcutsStore();
+const fileBrowserCtx = useFileBrowserContext();
 
 const isEditorOpen = ref(false);
 const isPinned = ref(false);
@@ -70,6 +82,15 @@ const breadcrumbsContainerRef = ref<HTMLElement | null>(null);
 const pathInputRef = ref<InstanceType<typeof Input> | null>(null);
 const separatorDropdowns = ref<{ [key: number]: string[] }>({});
 const openSeparatorIndex = ref<number | null>(null);
+
+function handleEditAddressBarShortcut() {
+  for (const instance of addressBarInstances) {
+    if (instance.isActivePane()) {
+      instance.openEditor();
+      return;
+    }
+  }
+}
 
 onClickOutside(
   addressBarRef,
@@ -340,13 +361,6 @@ async function openCopiedPath() {
   }
 }
 
-function handleGlobalKeydown(event: KeyboardEvent) {
-  if (event.ctrlKey && event.key === 'p') {
-    event.preventDefault();
-    openEditor();
-  }
-}
-
 let dropContainerId: number | null = null;
 
 onMounted(() => {
@@ -360,7 +374,15 @@ onMounted(() => {
     disableBackgroundDrop: true,
   });
 
-  window.addEventListener('keydown', handleGlobalKeydown);
+  addressBarInstances.push({
+    isActivePane: () => fileBrowserCtx.isActivePane(),
+    openEditor,
+  });
+
+  if (!shortcutHandlerRegistered) {
+    shortcutHandlerRegistered = true;
+    shortcutsStore.registerHandler('editAddressBar', handleEditAddressBarShortcut);
+  }
 });
 
 onUnmounted(() => {
@@ -368,7 +390,12 @@ onUnmounted(() => {
     unregisterDropContainer(dropContainerId);
   }
 
-  window.removeEventListener('keydown', handleGlobalKeydown);
+  const index = addressBarInstances.findIndex(
+    instance => instance.openEditor === openEditor,
+  );
+  if (index >= 0) {
+    addressBarInstances.splice(index, 1);
+  }
 });
 </script>
 
@@ -599,7 +626,7 @@ onUnmounted(() => {
         <TooltipContent>
           <div class="address-bar__tooltip-row">
             {{ t('settings.addressBar.editAddress') }}
-            <ContextMenuShortcut>Ctrl+P</ContextMenuShortcut>
+            <ContextMenuShortcut>{{ shortcutsStore.getShortcutLabel('editAddressBar') }}</ContextMenuShortcut>
           </div>
         </TooltipContent>
       </Tooltip>

--- a/src/modules/navigator/components/file-browser/address-bar.vue
+++ b/src/modules/navigator/components/file-browser/address-bar.vue
@@ -191,7 +191,9 @@ async function openEditor() {
   isEditorOpen.value = true;
 
   await nextTick();
-  pathInputRef.value?.$el?.focus();
+  const el = pathInputRef.value?.$el;
+  el?.focus();
+  el?.select();
   await updateAutocompleteList(initialPath);
 }
 

--- a/src/modules/navigator/components/file-browser/composables/use-file-browser-context.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-file-browser-context.ts
@@ -55,6 +55,8 @@ export interface FileBrowserContext {
 
   requestFocusEntryAfterRefresh: (parentDirectoryPath: string, entryPath: string) => void;
 
+  isActivePane: () => boolean;
+
   entryDescription?: (entry: DirEntry) => string | undefined;
 }
 

--- a/src/modules/navigator/components/file-browser/file-browser.vue
+++ b/src/modules/navigator/components/file-browser/file-browser.vue
@@ -105,6 +105,7 @@ provideFileBrowserContext({
   navigateToHome: fb.navigateToHome,
   refresh: fb.refresh,
   requestFocusEntryAfterRefresh: fb.requestFocusEntryAfterRefresh,
+  isActivePane: () => props.isActivePane ?? (props.paneIndex === 0 || props.paneIndex === undefined),
   entryDescription: props.entryDescription,
 });
 

--- a/src/modules/settings/ui/categories/shortcuts/shortcuts.vue
+++ b/src/modules/settings/ui/categories/shortcuts/shortcuts.vue
@@ -62,6 +62,7 @@ import {
   HomeIcon,
   FolderClosedIcon,
   BookmarkIcon,
+  TextCursorIcon,
 } from '@lucide/vue';
 import type { Component } from 'vue';
 import {
@@ -133,6 +134,7 @@ const shortcutIcons: Record<ShortcutId, Component> = {
   uiZoomIncrease: PlusIcon,
   uiZoomDecrease: MinusIcon,
   toggleFullscreen: FullscreenIcon,
+  editAddressBar: TextCursorIcon,
 };
 
 const globalShortcutIcons: Record<GlobalShortcutId, Component> = {

--- a/src/stores/runtime/__tests__/shortcuts.test.ts
+++ b/src/stores/runtime/__tests__/shortcuts.test.ts
@@ -591,4 +591,24 @@ describe('shortcuts store', () => {
 
     await expect(handlePromise).resolves.toBe(false);
   });
+
+  it('matches Ctrl+P for the default editAddressBar shortcut', async () => {
+    const shortcutsStore = useShortcutsStore();
+    const editAddressBarHandler = vi.fn();
+
+    shortcutsStore.registerHandler('editAddressBar', editAddressBarHandler);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'p',
+      code: 'KeyP',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    await expect(shortcutsStore.handleKeydown(event)).resolves.toBe(true);
+    expect(editAddressBarHandler).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
 });

--- a/src/stores/runtime/shortcuts.ts
+++ b/src/stores/runtime/shortcuts.ts
@@ -213,6 +213,20 @@ const DEFAULT_SHORTCUTS: ShortcutDefinition[] = [
     isReadOnly: false,
   },
   {
+    id: 'editAddressBar',
+    labelKey: 'shortcuts.toggleAddressBar',
+    defaultKeys: {
+      ctrl: true,
+      key: 'p',
+    },
+    scope: 'navigator',
+    conditions: {
+      inputFieldIsActive: false,
+      dialogIsOpened: false,
+    },
+    isReadOnly: false,
+  },
+  {
     id: 'copyCurrentDirectoryPath',
     labelKey: 'shortcuts.copyCurrentDirectoryPathToClipboard',
     defaultKeys: {

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -131,7 +131,8 @@ export type ShortcutId
     | 'reloadCurrentDirectory'
     | 'uiZoomIncrease'
     | 'uiZoomDecrease'
-    | 'toggleFullscreen';
+    | 'toggleFullscreen'
+    | 'editAddressBar';
 
 export type UserShortcuts = Partial<Record<ShortcutId, UserShortcutStoredValue>>;
 


### PR DESCRIPTION
1. When opening the address bar editor, the entire path text is now automatically selected. This follows the standard behavior found in file explorers and web browsers.

2. Custom shortcut for address editor
This commit makes the address bar editor shortcut customizable through the app's shortcut settings system, replacing the previously hardcoded `Ctrl+P` global keydown listener.

- A new `editAddressBar` shortcut was added to shortcuts.ts (default: `Ctrl+P`).
- Added UI to the settings panel for configuring the shortcut.
- The tooltip now displays the configured shortcut dynamically.
- Fixed the shortcut to only activate in the active pane when using split panes.
