### PR TITLE
Allow window dragging via empty space in nav-sidebar

### DIFF
--- a/src/modules/nav-sidebar/nav-sidebar.vue
+++ b/src/modules/nav-sidebar/nav-sidebar.vue
@@ -116,9 +116,13 @@ function getDriveIcon(drive: {
     class="nav-sidebar"
     data-e2e-root="nav-sidebar"
   >
-    <div class="nav-sidebar-header">
+    <div
+      class="nav-sidebar-header"
+      data-tauri-drag-region
+    >
       <div class="nav-sidebar-header-logo">
         <img
+          data-tauri-drag-region
           src="@/assets/icons/logo-32x32.png"
           width="20"
           height="20"
@@ -233,7 +237,10 @@ function getDriveIcon(drive: {
       </Tooltip>
     </div>
 
-    <div class="nav-sidebar-spacer" />
+    <div
+      class="nav-sidebar-spacer"
+      data-tauri-drag-region
+    />
 
     <div class="nav-sidebar-drives">
       <Tooltip


### PR DESCRIPTION
- Add window drag regions to the navigation sidebar header and empty spacer area
- Prevent unnecessary image dragging from the logo icon
- Keep sidebar navigation and drive buttons interactive by leaving them outside drag regions

This PR closes #485