### PR TITLE
Add file view settings for double-click timing and drag-and-drop

### DIFF
--- a/src/localization/messages/en.json
+++ b/src/localization/messages/en.json
@@ -244,6 +244,10 @@
       },
       "fileView": {
         "title": "File view",
+        "doubleClickDelay": "Double-click delay: {n} ms",
+        "doubleClickDelayDescription": "Increase the window used to detect a double click before opening files or folders.",
+        "enableDragAndDrop": "Enable drag and drop",
+        "enableDragAndDropDescription": "Turn this off to prevent accidental move or copy operations by dragging files and folders.",
         "enableBoxSelection": "Enable box selection",
         "enableBoxSelectionDescription": "Drag on empty space to select multiple items with a selection box. Hold Ctrl or Shift to add to the selection; hold Alt to invert.",
         "increaseFileViewGaps": "Increase file view gaps",
@@ -502,7 +506,7 @@
     "whatsNew": "what's new, changelog, release notes, version, update, news",
     "autostart": "autostart, startup, boot, login, launch, system, wake",
     "performance": "performance, memory, quick view, print, window, launch, preload",
-    "fileView": "file view, box selection, drag selection, list, grid, gaps, padding, spacing",
+    "fileView": "file view, double click, drag and drop, box selection, drag selection, list, grid, gaps, padding, spacing",
     "extensions": "extensions, plugins, addons, configuration, settings"
   },
   "drag": {

--- a/src/localization/messages/ja.json
+++ b/src/localization/messages/ja.json
@@ -215,6 +215,10 @@
       },
       "fileView": {
         "title": "ファイルビュー",
+        "doubleClickDelay": "ダブルクリック判定時間: {n} ms",
+        "doubleClickDelayDescription": "ファイルやフォルダーを開く前にダブルクリックとして判定する時間を長くできます。",
+        "enableDragAndDrop": "ドラッグアンドドロップを有効にする",
+        "enableDragAndDropDescription": "誤ってファイルやフォルダーを移動またはコピーしないよう、ドラッグ操作を無効にできます。",
         "enableBoxSelection": "ボックス選択を有効にする",
         "enableBoxSelectionDescription": "空白部分をドラッグして、選択ボックスで複数の項目を選択します。Ctrl または Shift を押しながらで追加、Alt を押しながらで反転します。",
         "increaseFileViewGaps": "ファイルビューの間隔を広げる",
@@ -474,7 +478,7 @@
     "extensions": "extensions, plugins, addons, configuration, settings",
     "infoPanelPreview": "info, panel, preview, image, thumbnail, memory, original, video, mute, autoplay",
     "performance": "performance, memory, quick view, print, window, launch, preload",
-    "fileView": "ファイルビュー, ボックス選択, ドラッグ選択, リスト, グリッド, 間隔, 余白"
+    "fileView": "ファイルビュー, ダブルクリック, ドラッグアンドドロップ, ボックス選択, ドラッグ選択, リスト, グリッド, 間隔, 余白"
   },
   "drag": {
     "holdShiftToChangeMode": "[Shift] を押してモードを変更",

--- a/src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-click-selection.test.ts
+++ b/src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-click-selection.test.ts
@@ -49,6 +49,7 @@ function createMouseEvent(overrides: Partial<MouseEvent> = {}): MouseEvent {
 
 function createClickSelectionHarness(options: {
   getCurrentTime?: () => number;
+  getDoubleClickDelayMs?: () => number;
 } = {}) {
   const selectedEntries = ref<DirEntry[]>([]);
   const lastSelectedEntry = ref<DirEntry | null>(null);
@@ -113,6 +114,7 @@ function createClickSelectionHarness(options: {
     onOpenProperties,
     onMiddleClickOpenInNewTab,
     isWindows: false,
+    getDoubleClickDelayMs: options.getDoubleClickDelayMs,
     getCurrentTime: options.getCurrentTime,
   });
 
@@ -244,6 +246,26 @@ describe('useFileBrowserClickSelection', () => {
     harness.handleEntryMouseUp(entry, createMouseEvent());
 
     expect(harness.onOpen).not.toHaveBeenCalled();
+  });
+
+  it('respects a custom double click delay from settings', () => {
+    let currentTime = 1000;
+    const entry = createEntry();
+    const harness = createClickSelectionHarness({
+      getCurrentTime: () => currentTime,
+      getDoubleClickDelayMs: () => 600,
+    });
+
+    harness.handleEntryMouseDown(entry, createMouseEvent());
+    harness.handleEntryMouseUp(entry, createMouseEvent());
+
+    currentTime += 500;
+
+    harness.handleEntryMouseDown(entry, createMouseEvent());
+    harness.handleEntryMouseUp(entry, createMouseEvent());
+
+    expect(harness.onOpen).toHaveBeenCalledTimes(1);
+    expect(harness.onOpen).toHaveBeenCalledWith(entry);
   });
 
   it('clears pending double click state on reset', () => {

--- a/src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-external-drop.test.ts
+++ b/src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-external-drop.test.ts
@@ -112,10 +112,13 @@ function createDropTarget(path: string): HTMLElement {
   return element;
 }
 
-async function mountExternalDrop() {
+async function mountExternalDrop(options: {
+  enabled?: boolean;
+} = {}) {
   const componentRef = ref<Element | null>(null);
   const currentPath = ref('/current');
   const entriesContainerRef = ref<Element | null>(null);
+  const enabled = ref(options.enabled ?? true);
   const onDrop = vi.fn<(sourcePaths: string[], targetPath: string, operation: DragOperationType) => void>();
   const onUrlDrop = vi.fn<(urls: string[], targetPath: string) => void>();
   let externalDrop = {} as ReturnType<typeof useFileBrowserExternalDrop>;
@@ -128,6 +131,7 @@ async function mountExternalDrop() {
         entriesContainerRef,
         onDrop,
         onUrlDrop,
+        enabled,
       });
 
       return {
@@ -235,5 +239,42 @@ describe('useFileBrowserExternalDrop', () => {
     });
 
     expect(mounted.onDrop).toHaveBeenCalledWith(['source.txt'], 'folder-b', 'move');
+  });
+
+  it('ignores external drops when drag and drop is disabled', async () => {
+    const mounted = await mountExternalDrop({ enabled: false });
+    mountedWrapper = mounted.wrapper;
+
+    setElementRect(mounted.componentRef.value, {
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+    });
+
+    const firstTarget = createDropTarget('folder-a');
+    mounted.entriesContainerRef.value.append(firstTarget);
+
+    dragDropHandler?.({
+      payload: {
+        type: 'enter',
+        paths: ['source.txt'],
+        position: {
+          x: 50,
+          y: 50,
+        },
+      },
+    });
+
+    dragDropHandler?.({
+      payload: {
+        type: 'drop',
+        paths: ['source.txt'],
+      },
+    });
+
+    expect(mounted.onDrop).not.toHaveBeenCalled();
+    expect(mounted.externalDrop.isExternalDragActive.value).toBe(false);
+    expect(firstTarget.hasAttribute('data-drag-over')).toBe(false);
   });
 });

--- a/src/modules/navigator/components/file-browser/composables/use-file-browser-click-selection.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-file-browser-click-selection.ts
@@ -51,9 +51,11 @@ export function useFileBrowserClickSelection(options: {
   onOpenProperties: (entries: DirEntry[]) => void;
   onMiddleClickOpenInNewTab: (entry: DirEntry) => void;
   isWindows: boolean;
+  getDoubleClickDelayMs?: () => number;
   getCurrentTime?: () => number;
 }) {
   const getCurrentTime = options.getCurrentTime ?? (() => Date.now());
+  const getDoubleClickDelayMs = options.getDoubleClickDelayMs ?? (() => UI_CONSTANTS.DOUBLE_CLICK_DELAY);
 
   const mouseDownState = ref<FileBrowserMouseDownState>({
     item: null,
@@ -113,7 +115,12 @@ export function useFileBrowserClickSelection(options: {
 
     const { wasSelected, pendingDoubleClick, ctrlKey, shiftKey } = mouseDownState.value;
     const currentTime = getCurrentTime();
-    const entryIsDoubleClick = isDoubleClick(pendingDoubleClick, entry.path, currentTime);
+    const entryIsDoubleClick = isDoubleClick(
+      pendingDoubleClick,
+      entry.path,
+      currentTime,
+      getDoubleClickDelayMs(),
+    );
 
     if (entryIsDoubleClick && !ctrlKey && !shiftKey) {
       clearPendingDoubleClick();

--- a/src/modules/navigator/components/file-browser/composables/use-file-browser-drag.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-file-browser-drag.ts
@@ -36,6 +36,7 @@ export function useFileBrowserDrag(options: {
   onDrop: FileBrowserDragDropHandler;
   fallbackDropHandler?: FileBrowserDragDropHandler | null;
   disableBackgroundDrop?: boolean;
+  enabled?: Ref<boolean>;
 }) {
   const dragSession = useFileBrowserDragSession();
   const crossPaneDropTargetPaneId = getCrossPaneDropTargetPaneId();
@@ -63,6 +64,7 @@ export function useFileBrowserDrag(options: {
 
   function handleDragMouseDown(entry: DirEntry, event: MouseEvent) {
     if (event.button !== 0) return;
+    if (options.enabled && !options.enabled.value) return;
 
     mouseDownEntry = entry;
     mouseDownX = event.clientX;
@@ -95,6 +97,10 @@ export function useFileBrowserDrag(options: {
   }
 
   function startDrag(entry: DirEntry, event: MouseEvent) {
+    if (options.enabled && !options.enabled.value) {
+      return;
+    }
+
     if (!options.isEntrySelected(entry)) {
       options.replaceSelection(entry);
     }

--- a/src/modules/navigator/components/file-browser/composables/use-file-browser-external-drop.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-file-browser-external-drop.ts
@@ -24,6 +24,7 @@ export function useFileBrowserExternalDrop(options: {
   onDrop: (sourcePaths: string[], targetPath: string, operation: DragOperationType) => void;
   onUrlDrop: (urls: string[], targetPath: string) => void;
   disableBackgroundDrop?: boolean;
+  enabled?: Ref<boolean>;
 }) {
   const dismissalLayerStore = useDismissalLayerStore();
   const dropOverlayStore = useDropOverlayStore();
@@ -270,6 +271,10 @@ export function useFileBrowserExternalDrop(options: {
     listen<UrlDropEventPayload>(
       'app://url-drop',
       (event) => {
+        if (options.enabled && !options.enabled.value) {
+          return;
+        }
+
         if (!isUrlDrop.value || !isExternalDragActive.value) {
           return;
         }
@@ -294,6 +299,11 @@ export function useFileBrowserExternalDrop(options: {
 
     getCurrentWebview()
       .onDragDropEvent((event) => {
+        if (options.enabled && !options.enabled.value) {
+          resetState();
+          return;
+        }
+
         if (isBackgroundManagerOpen.value) {
           return;
         }

--- a/src/modules/navigator/components/file-browser/composables/use-file-browser-selection.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-file-browser-selection.ts
@@ -31,6 +31,7 @@ import { createIndexedFileName, safeFileNameFromUrl } from '@/utils/remote-file'
 import { basenameFromPath } from '@/utils/source-display-name';
 import { usePermanentDeleteConfirm } from '@/composables/use-permanent-delete-confirm';
 import { usePlatformStore } from '@/stores/runtime/platform';
+import { useUserSettingsStore } from '@/stores/storage/user-settings';
 import { isContextMenuActionVisible } from '@/modules/navigator/components/file-browser/utils/context-menu-action-visibility';
 import { resolveNavigableItemTarget } from '@/utils/resolve-navigable-item-target';
 import type { CreateLinksResult, LinkCreationKind } from '@/utils/link-operations';
@@ -49,6 +50,7 @@ export function useFileBrowserSelection(
 ) {
   const { t } = useI18n();
   const platformStore = usePlatformStore();
+  const userSettingsStore = useUserSettingsStore();
   const workspacesStore = useWorkspacesStore();
   const userStatsStore = useUserStatsStore();
   const clipboardStore = useClipboardStore();
@@ -260,6 +262,7 @@ export function useFileBrowserSelection(
       void openEntriesInNewTabs([entry]);
     },
     isWindows: platformStore.isWindows,
+    getDoubleClickDelayMs: () => userSettingsStore.userSettings.navigator.doubleClickDelayMs,
   });
 
   function handleEntryFocus(entry: DirEntry, event: FocusEvent) {

--- a/src/modules/navigator/components/file-browser/composables/use-file-browser.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-file-browser.ts
@@ -263,6 +263,9 @@ export function useFileBrowser(options: UseFileBrowserOptions) {
   const enableBoxSelection = computed(
     () => userSettingsStore.userSettings.navigator.enableBoxSelection,
   );
+  const enableDragAndDrop = computed(
+    () => userSettingsStore.userSettings.navigator.enableDragAndDrop,
+  );
   const increaseFileViewGaps = computed(
     () => userSettingsStore.userSettings.navigator.increaseFileViewGaps,
   );
@@ -387,6 +390,7 @@ export function useFileBrowser(options: UseFileBrowserOptions) {
         operation,
       );
     },
+    enabled: enableDragAndDrop,
   });
 
   const boxSelection = useFileBrowserBoxSelection({
@@ -417,6 +421,7 @@ export function useFileBrowser(options: UseFileBrowserOptions) {
     onUrlDrop: (urls, targetPath) => {
       selection.handleExternalUrlDrop(urls, targetPath);
     },
+    enabled: enableDragAndDrop,
   });
 
   const actions = useFileBrowserActions({

--- a/src/modules/navigator/components/file-browser/utils/__tests__/file-browser-sort-columns.test.ts
+++ b/src/modules/navigator/components/file-browser/utils/__tests__/file-browser-sort-columns.test.ts
@@ -63,6 +63,8 @@ function createNavigatorSettings(overrides: Partial<UserSettingsNavigator> = {})
     listSortDirection: 'asc',
     gridSortColumn: 'name',
     gridSortDirection: 'asc',
+    doubleClickDelayMs: 300,
+    enableDragAndDrop: true,
     enableBoxSelection: false,
     increaseFileViewGaps: false,
     ...overrides,

--- a/src/modules/settings/ui/categories/general/file-view.vue
+++ b/src/modules/settings/ui/categories/general/file-view.vue
@@ -7,6 +7,7 @@ Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { MousePointerSquareDashedIcon } from '@lucide/vue';
+import { Slider } from '@/components/ui/slider';
 import { SettingsItem } from '@/modules/settings';
 import { Switch } from '@/components/ui/switch';
 import { useUserSettingsStore } from '@/stores/storage/user-settings';
@@ -14,12 +15,31 @@ import { useUserSettingsStore } from '@/stores/storage/user-settings';
 const { t } = useI18n();
 const userSettingsStore = useUserSettingsStore();
 
+function clampDoubleClickDelayMs(raw: number): number {
+  const bounded = Math.min(1000, Math.max(200, raw));
+  return Math.round(bounded / 50) * 50;
+}
+
 const enableBoxSelection = computed(
   () => userSettingsStore.userSettings.navigator.enableBoxSelection,
+);
+const enableDragAndDrop = computed(
+  () => userSettingsStore.userSettings.navigator.enableDragAndDrop,
 );
 const increaseFileViewGaps = computed(
   () => userSettingsStore.userSettings.navigator.increaseFileViewGaps,
 );
+const doubleClickDelaySlider = computed({
+  get: () => [clampDoubleClickDelayMs(userSettingsStore.userSettings.navigator.doubleClickDelayMs)],
+  set: (value: number[]) => {
+    const next = clampDoubleClickDelayMs(value[0]);
+    void userSettingsStore.set('navigator.doubleClickDelayMs', next);
+  },
+});
+
+async function onEnableDragAndDropChange(enabled: boolean) {
+  await userSettingsStore.set('navigator.enableDragAndDrop', enabled);
+}
 
 async function onEnableBoxSelectionChange(enabled: boolean) {
   await userSettingsStore.set('navigator.enableBoxSelection', enabled);
@@ -37,6 +57,39 @@ async function onIncreaseFileViewGapsChange(enabled: boolean) {
   >
     <template #nested>
       <div class="file-view-settings">
+        <div class="file-view-settings__row">
+          <div class="file-view-settings__copy">
+            <span class="file-view-settings__label">
+              {{ t('settings.general.fileView.doubleClickDelay', { n: doubleClickDelaySlider[0] }) }}
+            </span>
+            <p class="file-view-settings__description">
+              {{ t('settings.general.fileView.doubleClickDelayDescription') }}
+            </p>
+          </div>
+          <Slider
+            v-model="doubleClickDelaySlider"
+            :min="200"
+            :max="1000"
+            :step="50"
+            class="file-view-settings__slider"
+          />
+        </div>
+
+        <div class="file-view-settings__row">
+          <div class="file-view-settings__copy">
+            <span class="file-view-settings__label">
+              {{ t('settings.general.fileView.enableDragAndDrop') }}
+            </span>
+            <p class="file-view-settings__description">
+              {{ t('settings.general.fileView.enableDragAndDropDescription') }}
+            </p>
+          </div>
+          <Switch
+            :model-value="enableDragAndDrop"
+            @update:model-value="onEnableDragAndDropChange"
+          />
+        </div>
+
         <div class="file-view-settings__row">
           <div class="file-view-settings__copy">
             <span class="file-view-settings__label">
@@ -97,6 +150,10 @@ async function onIncreaseFileViewGapsChange(enabled: boolean) {
 .file-view-settings__label {
   color: hsl(var(--foreground));
   font-size: 0.875rem;
+}
+
+.file-view-settings__slider {
+  width: 200px;
 }
 
 .file-view-settings__description {

--- a/src/modules/tab-bar/tab/tab.vue
+++ b/src/modules/tab-bar/tab/tab.vue
@@ -107,10 +107,13 @@ const isActive = computed(() => (
 const canCloseAllDuplicateTabs = computed(() => workspacesStore.hasDuplicatePathTabs);
 const dropTargetTab = computed(() => props.tabGroup.find(tab => tab.type === 'directory'));
 const isFileBrowserDragActive = computed(() => activeFileBrowserDragState.value.isActive);
+const dragAndDropEnabled = computed(() => userSettingsStore.userSettings.navigator.enableDragAndDrop);
 const isTabPreviewDisabled = computed(() =>
   !(props.previewEnabled && showTabPreview) || isDropdownOpen.value || isFileBrowserDragActive.value,
 );
-const canDropOnTab = computed(() => isFileBrowserDragActive.value && !!dropTargetTab.value?.path);
+const canDropOnTab = computed(() =>
+  dragAndDropEnabled.value && isFileBrowserDragActive.value && !!dropTargetTab.value?.path,
+);
 
 const { start: startDragHoverOpenTimer, stop: stopDragHoverOpenTimer } = useTimeoutFn(() => {
   if (!isFileBrowserDragActive.value || isActive.value || props.tabGroup.length === 0) {

--- a/src/stores/storage/user-settings.ts
+++ b/src/stores/storage/user-settings.ts
@@ -139,6 +139,8 @@ export const useUserSettingsStore = defineStore('userSettings', () => {
       listSortDirection: 'asc',
       gridSortColumn: 'name',
       gridSortDirection: 'asc',
+      doubleClickDelayMs: 300,
+      enableDragAndDrop: true,
       enableBoxSelection: false,
       increaseFileViewGaps: false,
     },

--- a/src/types/user-settings.ts
+++ b/src/types/user-settings.ts
@@ -329,6 +329,8 @@ export type UserSettingsNavigator = {
   listSortDirection: ListSortDirection;
   gridSortColumn: ListSortColumn | null;
   gridSortDirection: ListSortDirection;
+  doubleClickDelayMs: number;
+  enableDragAndDrop: boolean;
   enableBoxSelection: boolean;
   increaseFileViewGaps: boolean;
 };


### PR DESCRIPTION
# PR Draft: Add file view settings for double-click timing and drag-and-drop

Target issue: https://github.com/aleksey-hoffman/sigma-file-manager/issues/506

## Title

Add file view settings for double-click timing and drag-and-drop

## Summary

- add a file-view slider for the double-click detection window
- add a file-view toggle to disable drag-and-drop moves and copies
- use the new settings in file-browser click selection, drag start, external drops, and tab drop targets
- cover the new behavior with focused interaction tests

## Why

Issue #506 asks for two safety-oriented file-view preferences: a longer double-click detection window and a way to disable drag-and-drop actions entirely. Right now Sigma uses a fixed `300ms` double-click threshold and always enables drag-and-drop, which makes accidental opens and accidental move/copy operations harder to avoid.

This patch exposes both controls in Settings and wires them into the actual interaction paths that perform those actions.

## Verification

```bash
npm install
npx vitest run src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-click-selection.test.ts src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-external-drop.test.ts
npx eslint src/modules/settings/ui/categories/general/file-view.vue src/modules/navigator/components/file-browser/composables/use-file-browser-click-selection.ts src/modules/navigator/components/file-browser/composables/use-file-browser-selection.ts src/modules/navigator/components/file-browser/composables/use-file-browser-drag.ts src/modules/navigator/components/file-browser/composables/use-file-browser-external-drop.ts src/modules/navigator/components/file-browser/composables/use-file-browser.ts src/modules/tab-bar/tab/tab.vue src/types/user-settings.ts src/stores/storage/user-settings.ts src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-click-selection.test.ts src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-external-drop.test.ts src/modules/navigator/components/file-browser/utils/__tests__/file-browser-sort-columns.test.ts
npm run type-check
git diff --check
```

Observed:

- `vitest`: `2 passed`, `12 passed`
- `eslint`: pass
- `type-check`: pass
- `git diff --check`: pass

## Scope Notes

- This patch is intentionally limited to the file-view settings and the drag/open interaction paths they control.
- It does not try to redesign broader file-browser preferences or localization coverage beyond the touched labels.
