### PR TITLE
Improve Linux file browser rendering performance

### DIFF
--- a/src-tauri/src/infusion_images.rs
+++ b/src-tauri/src/infusion_images.rs
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// License: GNU GPLv3 or later. See the license file in the project root for more information.
+// Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
+
+use std::fs;
+use std::fs::File;
+use std::io::{BufWriter, Cursor};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use image::codecs::jpeg::JpegEncoder;
+use image::{DynamicImage, GenericImageView, ImageFormat, ImageReader, Limits, RgbImage};
+use once_cell::sync::Lazy;
+use sha2::{Digest, Sha256};
+use tauri::Manager;
+
+const INFUSION_IMAGE_CACHE_DIR: &str = "infusion-images";
+const MAX_INPUT_IMAGE_BYTES: usize = 8 * 1024 * 1024;
+const MAX_INPUT_IMAGE_DIMENSION: u32 = 2_048;
+const MAX_INPUT_IMAGE_PIXELS: u64 = 4_194_304;
+const MAX_DECODE_ALLOCATION_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_BLUR_RADIUS: f32 = 128.0;
+const MIN_COLOR_FILTER_PERCENT: f32 = 0.0;
+const MAX_COLOR_FILTER_PERCENT: f32 = 200.0;
+const MAX_NOISE_STRENGTH: f32 = 1.0;
+const MIN_NOISE_SCALE: f32 = 0.1;
+const MAX_NOISE_SCALE: f32 = 8.0;
+const MAX_CACHE_ITEM_COUNT: usize = 32;
+const MAX_CACHE_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+const OUTPUT_JPEG_QUALITY: u8 = 88;
+
+static INFUSION_IMAGE_CACHE_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static TEMPORARY_IMAGE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn normalize_blur(value: f32) -> Result<f32, String> {
+    if !value.is_finite() {
+        return Err("Infusion image blur is invalid".to_string());
+    }
+
+    Ok((value.clamp(0.0, MAX_BLUR_RADIUS) * 100.0).round() / 100.0)
+}
+
+fn normalize_color_filter(value: f32, name: &str) -> Result<f32, String> {
+    if !value.is_finite() {
+        return Err(format!("Infusion image {name} is invalid"));
+    }
+
+    Ok((value.clamp(MIN_COLOR_FILTER_PERCENT, MAX_COLOR_FILTER_PERCENT) * 100.0).round() / 100.0)
+}
+
+fn normalize_noise_strength(value: f32) -> Result<f32, String> {
+    if !value.is_finite() {
+        return Err("Infusion image noise strength is invalid".to_string());
+    }
+
+    Ok((value.clamp(0.0, MAX_NOISE_STRENGTH) * 10_000.0).round() / 10_000.0)
+}
+
+fn normalize_noise_scale(value: f32) -> Result<f32, String> {
+    if !value.is_finite() {
+        return Err("Infusion image noise scale is invalid".to_string());
+    }
+
+    Ok((value.clamp(MIN_NOISE_SCALE, MAX_NOISE_SCALE) * 100.0).round() / 100.0)
+}
+
+fn decode_input_image_data_url(image_data_url: &str) -> Result<Vec<u8>, String> {
+    let (metadata, encoded_image) = image_data_url
+        .split_once(',')
+        .ok_or_else(|| "Infusion image data URL is invalid".to_string())?;
+
+    if metadata != "data:image/jpeg;base64" {
+        return Err("Infusion image data format is unsupported".to_string());
+    }
+
+    let estimated_size = encoded_image.len().saturating_mul(3) / 4;
+
+    if estimated_size > MAX_INPUT_IMAGE_BYTES {
+        return Err("Infusion image data is too large".to_string());
+    }
+
+    let image_bytes = BASE64_STANDARD
+        .decode(encoded_image)
+        .map_err(|error| format!("Failed to decode infusion image data: {error}"))?;
+
+    if image_bytes.is_empty() {
+        return Err("Infusion image data is empty".to_string());
+    }
+
+    if image_bytes.len() > MAX_INPUT_IMAGE_BYTES {
+        return Err("Infusion image data is too large".to_string());
+    }
+
+    Ok(image_bytes)
+}
+
+fn infusion_decode_limits() -> Limits {
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(MAX_INPUT_IMAGE_DIMENSION);
+    limits.max_image_height = Some(MAX_INPUT_IMAGE_DIMENSION);
+    limits.max_alloc = Some(MAX_DECODE_ALLOCATION_BYTES);
+    limits
+}
+
+fn decode_input_image(image_bytes: &[u8]) -> Result<DynamicImage, String> {
+    let mut reader = ImageReader::with_format(Cursor::new(image_bytes), ImageFormat::Jpeg);
+    reader.limits(infusion_decode_limits());
+    let image = reader
+        .decode()
+        .map_err(|error| format!("Failed to decode infusion image: {error}"))?;
+    let (width, height) = image.dimensions();
+    let pixel_count = u64::from(width).saturating_mul(u64::from(height));
+
+    if width == 0 || height == 0 || pixel_count > MAX_INPUT_IMAGE_PIXELS {
+        return Err("Infusion image dimensions are invalid".to_string());
+    }
+
+    Ok(image)
+}
+
+fn apply_color_filters(image: &mut RgbImage, contrast: f32, brightness: f32) {
+    let contrast_factor = contrast / 100.0;
+    let brightness_factor = brightness / 100.0;
+
+    if contrast_factor == 1.0 && brightness_factor == 1.0 {
+        return;
+    }
+
+    for pixel in image.pixels_mut() {
+        for channel in &mut pixel.0 {
+            let normalized = f32::from(*channel) / 255.0;
+            let adjusted =
+                (((normalized - 0.5) * contrast_factor + 0.5) * brightness_factor).clamp(0.0, 1.0);
+            *channel = (adjusted * 255.0).round() as u8;
+        }
+    }
+}
+
+fn noise_value(seed: u64, x: u32, y: u32) -> f32 {
+    let mut value = seed
+        ^ u64::from(x).wrapping_mul(0x9E37_79B1_85EB_CA87)
+        ^ u64::from(y).wrapping_mul(0xC2B2_AE3D_27D4_EB4F);
+    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^= value >> 31;
+    ((value >> 40) as f32) / 16_777_215.0
+}
+
+fn apply_noise(image: &mut RgbImage, strength: f32, scale: f32, seed: u64) {
+    if strength == 0.0 {
+        return;
+    }
+
+    let block_size = scale.max(1.0).round() as u32;
+
+    for (x, y, pixel) in image.enumerate_pixels_mut() {
+        let noise = noise_value(seed, x / block_size, y / block_size);
+
+        for channel in &mut pixel.0 {
+            let background = f32::from(*channel) / 255.0;
+            let overlay = if background < 0.5 {
+                2.0 * background * noise
+            } else {
+                1.0 - (2.0 * (1.0 - background) * (1.0 - noise))
+            };
+            let adjusted = (background * (1.0 - strength) + overlay * strength).clamp(0.0, 1.0);
+            *channel = (adjusted * 255.0).round() as u8;
+        }
+    }
+}
+
+fn infusion_noise_seed(image_bytes: &[u8]) -> u64 {
+    let hash = Sha256::digest(image_bytes);
+    let mut seed_bytes = [0u8; 8];
+    seed_bytes.copy_from_slice(&hash[..8]);
+    u64::from_le_bytes(seed_bytes)
+}
+
+fn hash_to_hex(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+}
+
+fn infusion_image_cache_key(
+    image_bytes: &[u8],
+    blur: f32,
+    contrast: f32,
+    brightness: f32,
+    noise_strength: f32,
+    noise_scale: f32,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"infusion-image-v1");
+    hasher.update([0]);
+    hasher.update(image_bytes);
+    hasher.update(blur.to_bits().to_le_bytes());
+    hasher.update(contrast.to_bits().to_le_bytes());
+    hasher.update(brightness.to_bits().to_le_bytes());
+    hasher.update(noise_strength.to_bits().to_le_bytes());
+    hasher.update(noise_scale.to_bits().to_le_bytes());
+    hash_to_hex(&hasher.finalize())
+}
+
+fn temporary_image_path(image_path: &Path) -> PathBuf {
+    let temporary_id = TEMPORARY_IMAGE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    image_path.with_extension(format!("tmp-{temporary_id}"))
+}
+
+fn write_processed_image(image: &DynamicImage, output_path: &Path) -> Result<(), String> {
+    let file = File::create(output_path)
+        .map_err(|error| format!("Failed to create processed infusion image: {error}"))?;
+    let writer = BufWriter::new(file);
+    let encoder = JpegEncoder::new_with_quality(writer, OUTPUT_JPEG_QUALITY);
+
+    image
+        .write_with_encoder(encoder)
+        .map_err(|error| format!("Failed to write processed infusion image: {error}"))
+}
+
+fn enforce_cache_limits(cache_dir: &Path, active_path: &Path) -> Result<(), String> {
+    let mut cache_items = fs::read_dir(cache_dir)
+        .map_err(|error| format!("Failed to read infusion image cache: {error}"))?
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let metadata = entry.metadata().ok()?;
+
+            if !metadata.is_file() || path == active_path {
+                return None;
+            }
+
+            let modified = metadata.modified().ok();
+            Some((path, metadata.len(), modified))
+        })
+        .collect::<Vec<_>>();
+    let mut total_size = cache_items.iter().fold(
+        fs::metadata(active_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0),
+        |size, item| size.saturating_add(item.1),
+    );
+    let mut total_count = cache_items.len() + usize::from(active_path.exists());
+
+    cache_items.sort_by_key(|item| item.2);
+
+    for (path, size, _) in cache_items {
+        if total_count <= MAX_CACHE_ITEM_COUNT && total_size <= MAX_CACHE_SIZE_BYTES {
+            break;
+        }
+
+        if fs::remove_file(path).is_ok() {
+            total_count = total_count.saturating_sub(1);
+            total_size = total_size.saturating_sub(size);
+        }
+    }
+
+    Ok(())
+}
+
+fn generate_infusion_image_file(
+    cache_dir: PathBuf,
+    image_data_url: String,
+    blur: f32,
+    contrast: f32,
+    brightness: f32,
+    noise_strength: f32,
+    noise_scale: f32,
+) -> Result<String, String> {
+    let blur = normalize_blur(blur)?;
+    let contrast = normalize_color_filter(contrast, "contrast")?;
+    let brightness = normalize_color_filter(brightness, "brightness")?;
+    let noise_strength = normalize_noise_strength(noise_strength)?;
+    let noise_scale = normalize_noise_scale(noise_scale)?;
+    let image_bytes = decode_input_image_data_url(&image_data_url)?;
+    let cache_key = infusion_image_cache_key(
+        &image_bytes,
+        blur,
+        contrast,
+        brightness,
+        noise_strength,
+        noise_scale,
+    );
+    let image_path = cache_dir.join(format!("{cache_key}.jpg"));
+    let _cache_lock = INFUSION_IMAGE_CACHE_LOCK
+        .lock()
+        .map_err(|error| format!("Failed to lock infusion image cache: {error}"))?;
+
+    fs::create_dir_all(&cache_dir)
+        .map_err(|error| format!("Failed to create infusion image cache: {error}"))?;
+
+    if image_path.exists() {
+        return Ok(image_path.to_string_lossy().to_string());
+    }
+
+    let image = decode_input_image(&image_bytes)?;
+    let processed_image = if blur > 0.0 { image.blur(blur) } else { image };
+    let mut rgb_image = processed_image.to_rgb8();
+    apply_color_filters(&mut rgb_image, contrast, brightness);
+    apply_noise(
+        &mut rgb_image,
+        noise_strength,
+        noise_scale,
+        infusion_noise_seed(&image_bytes),
+    );
+    let processed_image = DynamicImage::ImageRgb8(rgb_image);
+    let temporary_path = temporary_image_path(&image_path);
+
+    if let Err(error) = write_processed_image(&processed_image, &temporary_path) {
+        let _ = fs::remove_file(&temporary_path);
+        return Err(error);
+    }
+
+    if let Err(error) = fs::rename(&temporary_path, &image_path) {
+        let _ = fs::remove_file(&temporary_path);
+        return Err(format!(
+            "Failed to finalize processed infusion image: {error}"
+        ));
+    }
+
+    enforce_cache_limits(&cache_dir, &image_path)?;
+
+    Ok(image_path.to_string_lossy().to_string())
+}
+
+#[tauri::command]
+pub async fn generate_infusion_image(
+    app: tauri::AppHandle,
+    image_data_url: String,
+    blur: f32,
+    contrast: f32,
+    brightness: f32,
+    noise_strength: f32,
+    noise_scale: f32,
+) -> Result<String, String> {
+    let cache_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("Failed to resolve app data directory: {error}"))?
+        .join(INFUSION_IMAGE_CACHE_DIR);
+
+    tauri::async_runtime::spawn_blocking(move || {
+        generate_infusion_image_file(
+            cache_dir,
+            image_data_url,
+            blur,
+            contrast,
+            brightness,
+            noise_strength,
+            noise_scale,
+        )
+    })
+    .await
+    .map_err(|error| format!("Failed to generate infusion image: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        apply_color_filters, apply_noise, generate_infusion_image_file, infusion_image_cache_key,
+        MAX_INPUT_IMAGE_BYTES,
+    };
+    use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+    use base64::Engine;
+    use image::codecs::jpeg::JpegEncoder;
+    use image::{DynamicImage, Rgb, RgbImage};
+    use std::io::Cursor;
+
+    fn test_image_data_url() -> String {
+        let image = RgbImage::from_fn(32, 32, |x, y| Rgb([(x * 8) as u8, (y * 8) as u8, 128]));
+        let mut encoded = Vec::new();
+        DynamicImage::ImageRgb8(image)
+            .write_with_encoder(JpegEncoder::new_with_quality(Cursor::new(&mut encoded), 90))
+            .unwrap();
+        format!("data:image/jpeg;base64,{}", BASE64_STANDARD.encode(encoded))
+    }
+
+    #[test]
+    fn cache_key_changes_with_filters() {
+        let bytes = b"image";
+        let first = infusion_image_cache_key(bytes, 10.0, 100.0, 100.0, 0.0, 1.0);
+        let second = infusion_image_cache_key(bytes, 11.0, 100.0, 100.0, 0.0, 1.0);
+        let third = infusion_image_cache_key(bytes, 10.0, 110.0, 100.0, 0.0, 1.0);
+        let fourth = infusion_image_cache_key(bytes, 10.0, 100.0, 100.0, 0.1, 1.0);
+
+        assert_ne!(first, second);
+        assert_ne!(first, third);
+        assert_ne!(first, fourth);
+    }
+
+    #[test]
+    fn processed_images_are_cached() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let image_data_url = test_image_data_url();
+        let first = generate_infusion_image_file(
+            temp_dir.path().to_path_buf(),
+            image_data_url.clone(),
+            2.0,
+            100.0,
+            100.0,
+            0.025,
+            0.5,
+        )
+        .unwrap();
+        let second = generate_infusion_image_file(
+            temp_dir.path().to_path_buf(),
+            image_data_url,
+            2.0,
+            100.0,
+            100.0,
+            0.025,
+            0.5,
+        )
+        .unwrap();
+
+        assert_eq!(first, second);
+        assert!(std::path::Path::new(&first).is_file());
+    }
+
+    #[test]
+    fn color_filters_match_css_filter_order() {
+        let mut image = RgbImage::from_pixel(1, 1, Rgb([128, 64, 255]));
+        apply_color_filters(&mut image, 120.0, 80.0);
+
+        assert_eq!(image.get_pixel(0, 0).0, [102, 41, 224]);
+    }
+
+    #[test]
+    fn baked_noise_is_deterministic() {
+        let mut first = RgbImage::from_pixel(8, 8, Rgb([64, 128, 192]));
+        let mut second = first.clone();
+        apply_noise(&mut first, 0.25, 1.0, 42);
+        apply_noise(&mut second, 0.25, 1.0, 42);
+
+        assert_eq!(first, second);
+        assert_ne!(first.get_pixel(0, 0).0, [64, 128, 192]);
+    }
+
+    #[test]
+    fn oversized_input_is_rejected_before_decoding() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let oversized_data = "A".repeat((MAX_INPUT_IMAGE_BYTES * 4 / 3) + 8);
+        let result = generate_infusion_image_file(
+            temp_dir.path().to_path_buf(),
+            format!("data:image/jpeg;base64,{oversized_data}"),
+            0.0,
+            100.0,
+            100.0,
+            0.0,
+            1.0,
+        );
+
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod extensions;
 mod file_operations;
 mod global_search;
 mod image_thumbnails;
+mod infusion_images;
 mod input_simulation;
 mod lan_share;
 mod link_operations;
@@ -336,6 +337,7 @@ pub fn run() {
             image_thumbnails::cache_video_thumbnail,
             image_thumbnails::generate_image_thumbnail,
             image_thumbnails::get_cached_video_thumbnail,
+            infusion_images::generate_infusion_image,
             open_with::get_associated_programs,
             open_with::open_with_program,
             open_with::open_with_default,

--- a/src/components/ui/infusion/__tests__/infusion.test.ts
+++ b/src/components/ui/infusion/__tests__/infusion.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// License: GNU GPLv3 or later. See the license file in the project root for more information.
+// Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
+
+import { mount } from '@vue/test-utils';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import Infusion from '../infusion.vue';
+
+describe('infusion rendering', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not create a live CSS filter for static images', () => {
+    const wrapper = mount(Infusion, {
+      props: {
+        src: 'background.jpg',
+        blur: 64,
+        noiseIntensity: 0,
+      },
+    });
+
+    expect(wrapper.find('.infusion-media--filtered').exists()).toBe(false);
+    wrapper.unmount();
+  });
+
+  it('enables the live media filter for video when blur is visible', () => {
+    const wrapper = mount(Infusion, {
+      props: {
+        src: 'background.mp4',
+        type: 'video',
+        blur: 64,
+        noiseIntensity: 0,
+      },
+    });
+
+    expect(wrapper.get('.infusion-video').classes()).toContain('infusion-media--filtered');
+    wrapper.unmount();
+  });
+});

--- a/src/components/ui/infusion/__tests__/use-prepared-infusion-image.test.ts
+++ b/src/components/ui/infusion/__tests__/use-prepared-infusion-image.test.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// License: GNU GPLv3 or later. See the license file in the project root for more information.
+// Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
+
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const { mockInvoke } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  convertFileSrc: (path: string) => `asset://${path}`,
+  invoke: mockInvoke,
+}));
+
+import {
+  getCoverDrawRect,
+  getInfusionRasterSize,
+  prepareInfusionImage,
+} from '../use-prepared-infusion-image';
+
+describe('prepared infusion images', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    mockInvoke.mockReset();
+  });
+
+  it('bounds raster dimensions without upscaling small windows', () => {
+    expect(getInfusionRasterSize(2560, 1440)).toEqual({
+      width: 1200,
+      height: 675,
+    });
+    expect(getInfusionRasterSize(800, 600)).toEqual({
+      width: 800,
+      height: 600,
+    });
+    expect(getInfusionRasterSize(0, 600)).toBeNull();
+  });
+
+  it('calculates an object-cover draw rectangle', () => {
+    expect(getCoverDrawRect(4000, 4000, 1200, 675)).toEqual({
+      x: 0,
+      y: -262.5,
+      width: 1200,
+      height: 1200,
+    });
+  });
+
+  it('prepares a bounded raster and scales the native blur radius', async () => {
+    const drawImage = vi.fn();
+    const closeImage = vi.fn();
+    const canvasContext = {
+      drawImage,
+      fillRect: vi.fn(),
+      fillStyle: '',
+      imageSmoothingEnabled: false,
+      imageSmoothingQuality: 'low',
+    } as unknown as CanvasRenderingContext2D;
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      blob: vi.fn().mockResolvedValue(new Blob(['image'])),
+    }));
+    vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue({
+      width: 4000,
+      height: 4000,
+      close: closeImage,
+    }));
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(canvasContext);
+    vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL')
+      .mockReturnValue('data:image/jpeg;base64,cHJlcGFyZWQ=');
+    mockInvoke.mockResolvedValue('/tmp/generated-infusion.jpg');
+
+    const result = await prepareInfusionImage({
+      src: 'asset://background.jpg',
+      containerWidth: 2560,
+      containerHeight: 1440,
+      blur: 64,
+      contrast: 110,
+      brightness: 90,
+      noiseIntensity: 0.5,
+      noiseOpacity: 0.05,
+      noiseScale: 0.5,
+    });
+
+    expect(result).toBe('asset:///tmp/generated-infusion.jpg');
+    expect(drawImage).toHaveBeenCalledWith(
+      expect.anything(),
+      0,
+      -262.5,
+      1200,
+      1200,
+    );
+    expect(mockInvoke).toHaveBeenCalledWith('generate_infusion_image', {
+      imageDataUrl: 'data:image/jpeg;base64,cHJlcGFyZWQ=',
+      blur: 30,
+      contrast: 110,
+      brightness: 90,
+      noiseStrength: 0.025,
+      noiseScale: 0.5,
+    });
+    expect(closeImage).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/ui/infusion/infusion.vue
+++ b/src/components/ui/infusion/infusion.vue
@@ -5,6 +5,7 @@ Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
 
 <script setup lang="ts">
 import { computed, ref, watch, type CSSProperties } from 'vue';
+import { usePreparedInfusionImage } from './use-prepared-infusion-image';
 
 interface Props {
   src: string;
@@ -41,6 +42,19 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const videoElementRef = ref<HTMLVideoElement | null>(null);
+const containerElementRef = ref<HTMLDivElement | null>(null);
+
+const { preparedImageSrc } = usePreparedInfusionImage({
+  containerElementRef,
+  src: () => props.src,
+  type: () => props.type,
+  blur: () => props.blur,
+  contrast: () => props.mediaContrast,
+  brightness: () => props.mediaBrightness,
+  noiseIntensity: () => props.noiseIntensity,
+  noiseOpacity: () => props.noiseOpacity,
+  noiseScale: () => props.noiseScale,
+});
 
 watch(
   [() => props.pausePlayback, videoElementRef, () => props.type, () => props.src],
@@ -61,11 +75,15 @@ watch(
   { immediate: true },
 );
 
+const hasMediaFilter = computed(() => {
+  return props.blur > 0 || props.mediaContrast !== 100 || props.mediaBrightness !== 100;
+});
+
 const imageStyle = computed(() => ({
   '--infusion-opacity': props.opacity,
   '--infusion-opacity-dark': props.opacityDark,
   '--infusion-z-index': props.zIndex,
-  '--infusion-blur': `${props.blur}px`,
+  '--infusion-blur': `${Math.max(0, props.blur)}px`,
   '--infusion-noise-intensity': props.noiseIntensity,
   '--infusion-noise-scale': props.noiseScale,
   '--infusion-noise-opacity': props.noiseOpacity,
@@ -117,19 +135,21 @@ const containerClass = computed(() => [
 
 <template>
   <div
+    ref="containerElementRef"
     :class="containerClass"
     :style="imageStyle"
   >
     <img
-      v-if="props.type === 'image'"
+      v-if="props.type === 'image' && preparedImageSrc"
       class="infusion-image"
-      :src="props.src"
+      :src="preparedImageSrc"
       alt=""
     >
     <video
       v-if="props.type === 'video'"
       ref="videoElementRef"
       class="infusion-video"
+      :class="{ 'infusion-media--filtered': hasMediaFilter }"
       :src="props.src"
       autoplay
       loop
@@ -138,7 +158,7 @@ const containerClass = computed(() => [
       alt=""
     />
     <div
-      v-if="noiseIntensity > 0"
+      v-if="props.type === 'video' && noiseIntensity > 0"
       class="infusion-noise"
       :style="{ backgroundImage: `url(${noiseDataUrl})` }"
     />
@@ -166,24 +186,17 @@ const containerClass = computed(() => [
   height: 100%;
 }
 
-.infusion-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  opacity: var(--infusion-opacity);
-  transform: scale(1.1)
-}
-
-.dark .infusion-image {
-  opacity: var(--infusion-opacity-dark);
-}
-
+.infusion-image,
 .infusion-video {
   width: 100%;
   height: 100%;
   object-fit: cover;
   opacity: var(--infusion-opacity);
-  transform: scale(1.1)
+  transform: scale(1.1);
+}
+
+.dark .infusion-image {
+  opacity: var(--infusion-opacity-dark);
 }
 
 .dark .infusion-video {

--- a/src/components/ui/infusion/use-prepared-infusion-image.ts
+++ b/src/components/ui/infusion/use-prepared-infusion-image.ts
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// License: GNU GPLv3 or later. See the license file in the project root for more information.
+// Copyright © 2021 - present Aleksey Hoffman. All rights reserved.
+
+import {
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  type Ref,
+} from 'vue';
+import { convertFileSrc, invoke } from '@tauri-apps/api/core';
+
+const INFUSION_RASTER_MAX_DIMENSION = 1200;
+const INFUSION_PREPARE_DEBOUNCE_MS = 200;
+const INFUSION_RASTER_JPEG_QUALITY = 0.9;
+
+type InfusionRasterSize = {
+  width: number;
+  height: number;
+};
+
+type CoverDrawRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type DecodedImage = {
+  source: CanvasImageSource;
+  width: number;
+  height: number;
+  close: () => void;
+};
+
+export type PrepareInfusionImageOptions = {
+  src: string;
+  containerWidth: number;
+  containerHeight: number;
+  blur: number;
+  contrast: number;
+  brightness: number;
+  noiseIntensity: number;
+  noiseOpacity: number;
+  noiseScale: number;
+};
+
+type UsePreparedInfusionImageOptions = {
+  containerElementRef: Ref<HTMLElement | null>;
+  src: () => string;
+  type: () => 'image' | 'video';
+  blur: () => number;
+  contrast: () => number;
+  brightness: () => number;
+  noiseIntensity: () => number;
+  noiseOpacity: () => number;
+  noiseScale: () => number;
+};
+
+export function getInfusionRasterSize(
+  containerWidth: number,
+  containerHeight: number,
+): InfusionRasterSize | null {
+  if (
+    !Number.isFinite(containerWidth)
+    || !Number.isFinite(containerHeight)
+    || containerWidth <= 0
+    || containerHeight <= 0
+  ) {
+    return null;
+  }
+
+  const scale = Math.min(
+    1,
+    INFUSION_RASTER_MAX_DIMENSION / Math.max(containerWidth, containerHeight),
+  );
+
+  return {
+    width: Math.max(1, Math.round(containerWidth * scale)),
+    height: Math.max(1, Math.round(containerHeight * scale)),
+  };
+}
+
+export function getCoverDrawRect(
+  sourceWidth: number,
+  sourceHeight: number,
+  targetWidth: number,
+  targetHeight: number,
+): CoverDrawRect {
+  const coverScale = Math.max(targetWidth / sourceWidth, targetHeight / sourceHeight);
+  const width = sourceWidth * coverScale;
+  const height = sourceHeight * coverScale;
+
+  return {
+    x: (targetWidth - width) / 2,
+    y: (targetHeight - height) / 2,
+    width,
+    height,
+  };
+}
+
+async function decodeImageBlob(blob: Blob): Promise<DecodedImage> {
+  if (typeof createImageBitmap === 'function') {
+    const bitmap = await createImageBitmap(blob);
+
+    return {
+      source: bitmap,
+      width: bitmap.width,
+      height: bitmap.height,
+      close: () => bitmap.close(),
+    };
+  }
+
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    const image = new Image();
+    image.src = objectUrl;
+    await image.decode();
+
+    return {
+      source: image,
+      width: image.naturalWidth,
+      height: image.naturalHeight,
+      close: () => URL.revokeObjectURL(objectUrl),
+    };
+  }
+  catch (error) {
+    URL.revokeObjectURL(objectUrl);
+    throw error;
+  }
+}
+
+async function createInfusionRasterDataUrl(
+  src: string,
+  rasterSize: InfusionRasterSize,
+): Promise<string> {
+  const response = await fetch(src);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load infusion image: ${response.status}`);
+  }
+
+  const decodedImage = await decodeImageBlob(await response.blob());
+
+  try {
+    if (decodedImage.width <= 0 || decodedImage.height <= 0) {
+      throw new Error('Infusion image dimensions are invalid');
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = rasterSize.width;
+    canvas.height = rasterSize.height;
+    const context = canvas.getContext('2d');
+
+    if (!context) {
+      throw new Error('Infusion image canvas is unavailable');
+    }
+
+    const drawRect = getCoverDrawRect(
+      decodedImage.width,
+      decodedImage.height,
+      canvas.width,
+      canvas.height,
+    );
+    context.fillStyle = '#000';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.imageSmoothingEnabled = true;
+    context.imageSmoothingQuality = 'high';
+    context.drawImage(
+      decodedImage.source,
+      drawRect.x,
+      drawRect.y,
+      drawRect.width,
+      drawRect.height,
+    );
+
+    return canvas.toDataURL('image/jpeg', INFUSION_RASTER_JPEG_QUALITY);
+  }
+  finally {
+    decodedImage.close();
+  }
+}
+
+export async function prepareInfusionImage(
+  options: PrepareInfusionImageOptions,
+): Promise<string> {
+  const rasterSize = getInfusionRasterSize(
+    options.containerWidth,
+    options.containerHeight,
+  );
+
+  if (!rasterSize) {
+    throw new Error('Infusion image container dimensions are invalid');
+  }
+
+  const imageDataUrl = await createInfusionRasterDataUrl(options.src, rasterSize);
+  const rasterScale = Math.min(
+    rasterSize.width / options.containerWidth,
+    rasterSize.height / options.containerHeight,
+  );
+  const processedImagePath = await invoke<string>('generate_infusion_image', {
+    imageDataUrl,
+    blur: Math.max(0, options.blur) * rasterScale,
+    contrast: options.contrast,
+    brightness: options.brightness,
+    noiseStrength: Math.max(0, options.noiseIntensity) * Math.max(0, options.noiseOpacity),
+    noiseScale: options.noiseScale,
+  });
+
+  return convertFileSrc(processedImagePath);
+}
+
+export function usePreparedInfusionImage(options: UsePreparedInfusionImageOptions) {
+  const preparedImageSrc = ref('');
+  const isPreparingImage = ref(false);
+  let prepareTimer: ReturnType<typeof setTimeout> | null = null;
+  let preparationGeneration = 0;
+  let resizeObserver: ResizeObserver | null = null;
+
+  function cancelPrepareTimer() {
+    if (prepareTimer !== null) {
+      clearTimeout(prepareTimer);
+      prepareTimer = null;
+    }
+  }
+
+  function schedulePreparation(clearCurrentImage = false) {
+    preparationGeneration += 1;
+    const generation = preparationGeneration;
+    cancelPrepareTimer();
+
+    if (clearCurrentImage) {
+      preparedImageSrc.value = '';
+    }
+
+    if (options.type() !== 'image' || !options.src()) {
+      preparedImageSrc.value = '';
+      isPreparingImage.value = false;
+      return;
+    }
+
+    prepareTimer = setTimeout(async () => {
+      prepareTimer = null;
+      const containerElement = options.containerElementRef.value;
+
+      if (!containerElement) {
+        return;
+      }
+
+      isPreparingImage.value = true;
+
+      try {
+        const nextImageSrc = await prepareInfusionImage({
+          src: options.src(),
+          containerWidth: containerElement.clientWidth,
+          containerHeight: containerElement.clientHeight,
+          blur: options.blur(),
+          contrast: options.contrast(),
+          brightness: options.brightness(),
+          noiseIntensity: options.noiseIntensity(),
+          noiseOpacity: options.noiseOpacity(),
+          noiseScale: options.noiseScale(),
+        });
+
+        if (generation === preparationGeneration) {
+          preparedImageSrc.value = nextImageSrc;
+        }
+      }
+      catch {
+        if (generation === preparationGeneration) {
+          preparedImageSrc.value = '';
+        }
+      }
+      finally {
+        if (generation === preparationGeneration) {
+          isPreparingImage.value = false;
+        }
+      }
+    }, INFUSION_PREPARE_DEBOUNCE_MS);
+  }
+
+  watch(
+    [options.src, options.type],
+    () => schedulePreparation(true),
+  );
+
+  watch(
+    [
+      options.blur,
+      options.contrast,
+      options.brightness,
+      options.noiseIntensity,
+      options.noiseOpacity,
+      options.noiseScale,
+    ],
+    () => schedulePreparation(),
+  );
+
+  onMounted(() => {
+    const containerElement = options.containerElementRef.value;
+
+    if (containerElement && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => schedulePreparation());
+      resizeObserver.observe(containerElement);
+    }
+
+    schedulePreparation(true);
+  });
+
+  onBeforeUnmount(() => {
+    preparationGeneration += 1;
+    cancelPrepareTimer();
+    resizeObserver?.disconnect();
+  });
+
+  return {
+    preparedImageSrc,
+  };
+}

--- a/src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-virtual-layout.test.ts
+++ b/src/modules/navigator/components/file-browser/composables/__tests__/use-file-browser-virtual-layout.test.ts
@@ -302,3 +302,54 @@ describe('resolveViewportContentWidth', () => {
     wrapper.unmount();
   });
 });
+
+describe('useFileBrowserVirtualLayout scrolling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces multiple scroll events into one reactive update per frame', () => {
+    const viewport = document.createElement('div');
+    const animationFrames: FrameRequestCallback[] = [];
+    let scrollTop!: Ref<number>;
+    let handleScroll!: (event: Event) => void;
+
+    Object.defineProperty(viewport, 'clientHeight', {
+      value: 600,
+      configurable: true,
+    });
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const wrapper = mount(defineComponent({
+      setup() {
+        const virtualLayout = useFileBrowserVirtualLayout({
+          entries: computed(() => []),
+          layout: () => 'list',
+        });
+
+        scrollTop = virtualLayout.scrollTop;
+        handleScroll = virtualLayout.handleScroll;
+        virtualLayout.setScrollViewportRef(viewport);
+
+        return () => h('div');
+      },
+    }));
+
+    viewport.scrollTop = 120;
+    handleScroll({ currentTarget: viewport } as unknown as Event);
+    viewport.scrollTop = 240;
+    handleScroll({ currentTarget: viewport } as unknown as Event);
+
+    expect(animationFrames).toHaveLength(1);
+    expect(scrollTop.value).toBe(0);
+
+    animationFrames[0](0);
+
+    expect(scrollTop.value).toBe(240);
+    wrapper.unmount();
+  });
+});

--- a/src/modules/navigator/components/file-browser/composables/__tests__/use-image-thumbnails.test.ts
+++ b/src/modules/navigator/components/file-browser/composables/__tests__/use-image-thumbnails.test.ts
@@ -124,6 +124,22 @@ describe('normalizeImageThumbnailMaxDimension', () => {
 });
 
 describe('useImageThumbnails', () => {
+  it('updates thumbnail cache keys without replacing the reactive cache', async () => {
+    mockInvoke.mockImplementation((_command, payload: { path: string }) => {
+      return Promise.resolve(`${payload.path}.thumbnail.png`);
+    });
+
+    const thumbnails = useImageThumbnails();
+    const cacheReference = thumbnails.imageThumbnails.value;
+
+    thumbnails.getImageThumbnail(createImageEntry('image-1.jpg'));
+    thumbnails.getImageThumbnail(createImageEntry('image-2.jpg'));
+    await flushThumbnailWork();
+
+    expect(thumbnails.imageThumbnails.value).toBe(cacheReference);
+    expect(Object.keys(cacheReference)).toHaveLength(2);
+  });
+
   it('removes queued thumbnail requests when they are cancelled', async () => {
     const pendingRequests: Deferred<string>[] = [];
     mockInvoke.mockImplementation(() => {

--- a/src/modules/navigator/components/file-browser/composables/__tests__/use-video-thumbnails.test.ts
+++ b/src/modules/navigator/components/file-browser/composables/__tests__/use-video-thumbnails.test.ts
@@ -76,6 +76,22 @@ describe('normalizeVideoThumbnailSize', () => {
 });
 
 describe('useVideoThumbnails', () => {
+  it('updates thumbnail cache keys without replacing the reactive cache', async () => {
+    mockInvoke.mockImplementation((_command, payload: { path: string }) => {
+      return Promise.resolve(`${payload.path}.thumbnail.jpg`);
+    });
+
+    const thumbnails = useVideoThumbnails();
+    const cacheReference = thumbnails.videoThumbnails.value;
+
+    thumbnails.getVideoThumbnail(createVideoEntry('video-1.mp4'));
+    thumbnails.getVideoThumbnail(createVideoEntry('video-2.mp4'));
+    await flushThumbnailWork();
+
+    expect(thumbnails.videoThumbnails.value).toBe(cacheReference);
+    expect(Object.keys(cacheReference)).toHaveLength(2);
+  });
+
   it('removes queued thumbnail requests when they are cancelled', async () => {
     const pendingRequests: Deferred<string | null>[] = [];
     mockInvoke.mockImplementation(() => {

--- a/src/modules/navigator/components/file-browser/composables/use-file-browser-virtual-layout.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-file-browser-virtual-layout.ts
@@ -332,6 +332,8 @@ export function useFileBrowserVirtualLayout(options: {
   const scrollTop = ref(0);
   const virtualContentOffset = ref(0);
   let viewportResizeObserver: ResizeObserver | null = null;
+  let scrollUpdateFrame: number | null = null;
+  let pendingScrollTop: number | null = null;
 
   const gridGap = computed(() => getFileBrowserGridGap(!!options.increaseFileViewGaps?.()));
   const gridColumnCount = computed(() => getGridColumnCount(viewportWidth.value, gridGap.value));
@@ -364,6 +366,10 @@ export function useFileBrowserVirtualLayout(options: {
     return rowItems.slice(visibleRange.start, visibleRange.end);
   });
 
+  const gridSectionRows = computed(() => {
+    return rows.value.filter((row): row is FileBrowserGridSectionVirtualRow => row.type === 'grid-section');
+  });
+
   const activeGridSectionRow = computed(() => {
     if (options.layout() !== 'grid') {
       return null;
@@ -372,14 +378,12 @@ export function useFileBrowserVirtualLayout(options: {
     let activeRow: FileBrowserGridSectionVirtualRow | null = null;
     const virtualScrollTop = Math.max(0, scrollTop.value - virtualContentOffset.value);
 
-    for (const row of rows.value) {
+    for (const row of gridSectionRows.value) {
       if (row.start > virtualScrollTop) {
         break;
       }
 
-      if (row.type === 'grid-section') {
-        activeRow = row;
-      }
+      activeRow = row;
     }
 
     return activeRow;
@@ -472,7 +476,20 @@ export function useFileBrowserVirtualLayout(options: {
         observeViewportSize();
       }
 
-      scrollTop.value = Math.max(0, viewport.scrollTop);
+      pendingScrollTop = Math.max(0, viewport.scrollTop);
+
+      if (scrollUpdateFrame !== null) {
+        return;
+      }
+
+      scrollUpdateFrame = requestAnimationFrame(() => {
+        scrollUpdateFrame = null;
+
+        if (pendingScrollTop !== null) {
+          scrollTop.value = pendingScrollTop;
+          pendingScrollTop = null;
+        }
+      });
     }
   }
 
@@ -578,6 +595,13 @@ export function useFileBrowserVirtualLayout(options: {
 
     const maxScrollTop = getMaxScrollTop();
     const normalizedScrollTop = Math.min(Math.max(0, nextScrollTop), maxScrollTop);
+    pendingScrollTop = null;
+
+    if (scrollUpdateFrame !== null) {
+      cancelAnimationFrame(scrollUpdateFrame);
+      scrollUpdateFrame = null;
+    }
+
     viewport.scrollTop = normalizedScrollTop;
     scrollTop.value = normalizedScrollTop;
   }
@@ -674,6 +698,11 @@ export function useFileBrowserVirtualLayout(options: {
 
   onBeforeUnmount(() => {
     disconnectViewportResizeObserver();
+
+    if (scrollUpdateFrame !== null) {
+      cancelAnimationFrame(scrollUpdateFrame);
+      scrollUpdateFrame = null;
+    }
   });
 
   return {

--- a/src/modules/navigator/components/file-browser/composables/use-image-thumbnails.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-image-thumbnails.ts
@@ -170,10 +170,7 @@ export function useImageThumbnails() {
       });
 
       if (request.generation === thumbnailGeneration && !cancelledThumbnails.has(processingKey)) {
-        imageThumbnails.value = {
-          ...imageThumbnails.value,
-          [request.thumbnailKey]: convertFileSrc(thumbnailPath),
-        };
+        imageThumbnails.value[request.thumbnailKey] = convertFileSrc(thumbnailPath);
       }
     }
     catch {
@@ -244,10 +241,7 @@ export function useImageThumbnails() {
         && !cancelledPlaceholders.has(processingKey)
         && !imageThumbnails.value[request.thumbnailKey]
       ) {
-        imageThumbnailPlaceholders.value = {
-          ...imageThumbnailPlaceholders.value,
-          [request.thumbnailKey]: placeholderDataUrl,
-        };
+        imageThumbnailPlaceholders.value[request.thumbnailKey] = placeholderDataUrl;
       }
       else if (
         !placeholderDataUrl

--- a/src/modules/navigator/components/file-browser/composables/use-video-thumbnails.ts
+++ b/src/modules/navigator/components/file-browser/composables/use-video-thumbnails.ts
@@ -193,10 +193,7 @@ export function useVideoThumbnails() {
 
       if (cachedThumbnail) {
         if (request.generation === thumbnailGeneration && !cancelledThumbnails.has(processingKey)) {
-          videoThumbnails.value = {
-            ...videoThumbnails.value,
-            [request.thumbnailKey]: cachedThumbnail,
-          };
+          videoThumbnails.value[request.thumbnailKey] = cachedThumbnail;
         }
 
         return;
@@ -226,10 +223,7 @@ export function useVideoThumbnails() {
       }
 
       if (request.generation === thumbnailGeneration && !cancelledThumbnails.has(processingKey)) {
-        videoThumbnails.value = {
-          ...videoThumbnails.value,
-          [request.thumbnailKey]: thumbnailSrc,
-        };
+        videoThumbnails.value[request.thumbnailKey] = thumbnailSrc;
       }
     }
     catch {

--- a/src/modules/navigator/components/file-browser/file-browser-grid-view.vue
+++ b/src/modules/navigator/components/file-browser/file-browser-grid-view.vue
@@ -205,7 +205,6 @@ function getSectionRowStyle(row: FileBrowserGridSectionVirtualRow): Record<strin
 .file-browser-grid-view__section-bar-wrapper {
   padding-top: 8px;
   padding-bottom: 2px;
-  backdrop-filter: blur(var(--backdrop-filter-blur));
   background-color: hsl(var(--background-3));
   color: hsl(var(--muted-foreground));
   font-size: 12px;
@@ -224,7 +223,6 @@ function getSectionRowStyle(row: FileBrowserGridSectionVirtualRow): Record<strin
 .file-browser-grid-view__sticky-section-content {
   padding-top: 8px;
   padding-bottom: 2px;
-  backdrop-filter: blur(var(--backdrop-filter-blur));
   background-color: hsl(var(--background-3));
   color: hsl(var(--muted-foreground));
   font-size: 12px;

--- a/src/stores/storage/__tests__/user-settings.test.ts
+++ b/src/stores/storage/__tests__/user-settings.test.ts
@@ -9,6 +9,7 @@ import {
 import { createPinia, setActivePinia } from 'pinia';
 import { USER_SETTINGS_SCHEMA_VERSION } from '@/stores/schemas/user-settings';
 import {
+  BODY_VISUAL_FILTERS_ENABLED_CLASS,
   USER_SETTINGS_THEME_CHANGED_EVENT,
   useUserSettingsStore,
 } from '@/stores/storage/user-settings';
@@ -149,6 +150,28 @@ describe('user settings theme sync', () => {
     expect(lazyStoreSetMock).not.toHaveBeenCalled();
     expect(lazyStoreSaveMock).not.toHaveBeenCalled();
     expect(emitMock).not.toHaveBeenCalled();
+  });
+
+  it('avoids the full-page filter layer while visual filters are neutral', () => {
+    useUserSettingsStore();
+
+    expect(document.documentElement.classList.contains(BODY_VISUAL_FILTERS_ENABLED_CLASS)).toBe(false);
+    expect(document.documentElement.style.getPropertyValue('--sigma-visual-filter-brightness')).toBe('100');
+    expect(document.documentElement.style.getPropertyValue('--sigma-visual-filter-contrast')).toBe('100');
+  });
+
+  it('enables the full-page filter layer only for non-neutral visual filters', async () => {
+    const userSettingsStore = useUserSettingsStore();
+
+    userSettingsStore.userSettings.visualFilters.brightness = 110;
+    await nextTick();
+
+    expect(document.documentElement.classList.contains(BODY_VISUAL_FILTERS_ENABLED_CLASS)).toBe(true);
+
+    userSettingsStore.userSettings.visualFilters.brightness = 100;
+    await nextTick();
+
+    expect(document.documentElement.classList.contains(BODY_VISUAL_FILTERS_ENABLED_CLASS)).toBe(false);
   });
 });
 

--- a/src/stores/storage/user-settings.ts
+++ b/src/stores/storage/user-settings.ts
@@ -53,6 +53,7 @@ import {
 } from '@/modules/navigator/utils/resolve-navigator-folder-settings';
 
 export const USER_SETTINGS_THEME_CHANGED_EVENT = 'user-settings:theme-changed';
+export const BODY_VISUAL_FILTERS_ENABLED_CLASS = 'sigma-visual-filters-enabled';
 
 type ThemeChangedEventPayload = {
   theme: Theme;
@@ -306,6 +307,10 @@ export const useUserSettingsStore = defineStore('userSettings', () => {
     const brightness = clampVisualFilterValue(visualFilters.brightness);
     const contrast = clampVisualFilterValue(visualFilters.contrast);
 
+    document.documentElement.classList.toggle(
+      BODY_VISUAL_FILTERS_ENABLED_CLASS,
+      brightness !== 100 || contrast !== 100,
+    );
     document.documentElement.style.setProperty('--sigma-visual-filter-brightness', String(brightness));
     document.documentElement.style.setProperty('--sigma-visual-filter-contrast', String(contrast));
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -32,18 +32,25 @@
     overflow: hidden;
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
+  }
+
+  html.sigma-visual-filters-enabled body {
     filter: brightness(calc(var(--sigma-visual-filter-brightness, 100) * 1%))
       contrast(calc(var(--sigma-visual-filter-contrast, 100) * 1%));
   }
 
-  img,
-  video {
+  html.sigma-visual-filters-enabled img,
+  html.sigma-visual-filters-enabled video {
     filter: contrast(calc(100% * 100 / var(--sigma-visual-filter-contrast, 100)))
       brightness(calc(100% * 100 / var(--sigma-visual-filter-brightness, 100)));
   }
 
-  .infusion-image,
-  .infusion-video {
+  .infusion-media--filtered {
+    filter: blur(var(--infusion-blur)) contrast(var(--infusion-media-contrast))
+      brightness(var(--infusion-media-brightness));
+  }
+
+  html.sigma-visual-filters-enabled .infusion-media--filtered {
     filter: blur(var(--infusion-blur)) contrast(var(--infusion-media-contrast))
       brightness(var(--infusion-media-brightness))
       contrast(calc(100% * 100 / var(--sigma-visual-filter-contrast, 100)))


### PR DESCRIPTION
## Summary

- prerender and cache static Infusion image backgrounds in the native layer instead of applying a live full-window CSS blur
- skip neutral document-wide visual filters and redundant backdrop filters
- coalesce virtual-layout scroll updates to one animation frame
- update thumbnail cache entries in place instead of cloning the complete reactive cache
- keep the existing live filter path for video backgrounds

## Why

On Linux WebKitGTK, combining a live full-viewport blur with document-wide filters made grid scrolling and even small UI interactions visibly lag. Preparing a bounded raster once moves that work off the render hot path while preserving the Infusion appearance.

Addresses #504.
Related to #275.

## Validation

- user-tested native production build on CachyOS, Hyprland/Wayland via XWayland, WebKitGTK 2.52.6; scrolling is smooth and the Infusion background remains readable
- Node 24.16.0: 156 test files passed, 1044 tests passed
- vue-tsc --build
- ESLint and Stylelint on every changed frontend file
- cargo test --lib: 139 tests passed
- cargo fmt --all -- --check
- NO_STRIP=true npx tauri build --no-bundle

## Notes

- no new dependencies
- generated images are bounded to 1200 px and the native cache is limited to 32 items / 128 MiB
- full-repository npm run check currently encounters 14 pre-existing ESLint errors in unrelated, untouched files; all changed files pass linting
